### PR TITLE
feat: s3 bucket supports versioning

### DIFF
--- a/aws-s3-bucket.yml
+++ b/aws-s3-bucket.yml
@@ -34,7 +34,7 @@ plans:
   description: 'Public-read S3 bucket'
   display_name: 'Public Read'
   properties:
-    acl: public-read    
+    acl: public-read
 provision:
   plan_inputs:
     - field_name: acl
@@ -55,6 +55,11 @@ provision:
       details: Name of bucket
       default: csb-${request.instance_id}
       plan_updateable: true
+    - field_name: enable_versioning
+      type: boolean
+      details: Enable bucket versioning
+      default: false
+      prohibit_update: true
     - field_name: region
       type: string
       details: The region of the S3 bucket instance.

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -1,7 +1,7 @@
 ## Release notes for next release:
 
 ### New feature:
-
+- S3 bucket: versioning can be enabled for each bucket created by setting `enable_versioning` in the plan properties or in the service instance create request. 
 
 ### Fix:
 

--- a/terraform/s3/provision/main.tf
+++ b/terraform/s3/provision/main.tf
@@ -16,5 +16,9 @@ resource "aws_s3_bucket" "b" {
   bucket = var.bucket_name
   acl    = var.acl
 
+  versioning {
+    enabled = var.enable_versioning
+  }
+
   tags = var.labels
 }

--- a/terraform/s3/provision/variables.tf
+++ b/terraform/s3/provision/variables.tf
@@ -15,3 +15,4 @@
 variable bucket_name { type = string }
 variable acl { type = string }
 variable labels { type = map }
+variable enable_versioning { type = bool }


### PR DESCRIPTION
By default versioning is disabled, but can be enabled in plan configuration or during service instance creation.
Update of the versioning is prohibited since we are not sure of the side effects.

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

