### PR TITLE
chore: introduce a check for conventional commits on PR messages

### DIFF
--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -1,0 +1,25 @@
+name: Conventional Commit Check
+
+on: [pull_request]
+
+jobs:
+  conventional-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const {data: pr} = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            })
+
+            const allowed = ["feat\\!", "feat", "fix", "chore", "docs", "build", "test"]
+            const re = new RegExp(`^(` + allowed.join('|') + `)(\\(\\w+\\))?: `)
+            const title = pr['title']
+
+            if (!re.test(title)) {
+               throw new Error(`PR title "${title}" does not match conventional commits filter: ${re}`)
+            }


### PR DESCRIPTION
We decided as a team to try conventional commits as a way to make the
commit history easier to understand - particularaly when writing release
notes. This filter will nudge folks to get the PR titles right.

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~ N/A
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

