### PR TITLE
fix: minimum constraint on storage_gb for MySQL and PostgreSQL

### DIFF
--- a/aws-mysql.yml
+++ b/aws-mysql.yml
@@ -25,7 +25,7 @@ plan_updateable: true
 plans:
 - name: small
   id: 2268ce43-7fd7-48dc-be2f-8611e11fb12e
-  description: 'MySQL v5.7, minumum 2 cores, minumum 4GB ram, 5GB storage'
+  description: 'MySQL v5.7, minimum 2 cores, minimum 4GB ram, 5GB storage'
   display_name: "small"
   properties:
     cores: 2
@@ -34,7 +34,7 @@ plans:
     subsume: false
 - name: medium
   id: f2ae0bb7-6921-43b7-bae7-6d1fe1c5d1c6
-  description: 'MySQL v5.7, minumum 4 cores, minumum 8GB ram, 10GB storage'
+  description: 'MySQL v5.7, minimum 4 cores, minimum 8GB ram, 10GB storage'
   display_name: "medium"
   properties:
     cores: 4
@@ -43,7 +43,7 @@ plans:
     subsume: false
 - name: large
   id: a5fea013-e87f-488f-969d-1cf038881b57
-  description: 'MySQL v5.7, minumum 8 cores, minumum 16GB ram, 20GB storage'
+  description: 'MySQL v5.7, minimum 8 cores, minimum 16GB ram, 20GB storage'
   display_name: "large"
   properties:
     cores: 8
@@ -76,7 +76,7 @@ provision:
     default: 5
     constraints:
       maximum: 4096
-      minumum: 5
+      minimum: 5
   - field_name: subsume
     type: boolean
     details: Indicates an existing PostgreSQL instnace should be subsumed      

--- a/aws-postgresql.yml
+++ b/aws-postgresql.yml
@@ -25,7 +25,7 @@ plan_updateable: true
 plans:
 - name: small
   id: ffc51616-228b-41bd-bed1-d601c18d58f5
-  description: 'PostgreSQL 11, minumum 2 cores, minumum 4GB ram, 5GB storage'
+  description: 'PostgreSQL 11, minimum 2 cores, minimum 4GB ram, 5GB storage'
   display_name: "small"
   properties:
     cores: 2
@@ -34,7 +34,7 @@ plans:
     subsume: false
 - name: medium
   id: e64d07f9-ceb2-40a6-abd9-391047fa3cf5
-  description: 'PostgreSQL 11, minumum 4 cores, minumum 8GB ram, 10GB storage'
+  description: 'PostgreSQL 11, minimum 4 cores, minimum 8GB ram, 10GB storage'
   display_name: "medium"
   properties:
     cores: 4
@@ -43,7 +43,7 @@ plans:
     subsume: false
 - name: large
   id: 48baef10-a14c-4ae1-aab5-25f26eba941a
-  description: 'PostgreSQL 11, minumum 8 cores, minumum 16GB ram, 20GB storage'
+  description: 'PostgreSQL 11, minimum 8 cores, minimum 16GB ram, 20GB storage'
   display_name: "large"
   properties:
     cores: 8
@@ -99,7 +99,7 @@ provision:
     default: 5
     constraints:
       maximum: 4096
-      minumum: 5
+      minimum: 5
   - field_name: subsume
     type: boolean
     details: Indicates an existing PostgreSQL instnace should be subsumed

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -3,3 +3,4 @@
 ### New feature:
 
 ### Fix:
+- minimum constraints on MySQL and PostreSQL storage_gb are now enforced


### PR DESCRIPTION
### Checklist:

* [X] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

