### PR TITLE
chore: improve Go version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ help: ## list Makefile targets
 
 ###### Setup ##################################################################
 IAAS=aws
+GO-VERSION = 1.18.1
+GO-VER = go$(GO-VERSION)
 CSB_VERSION := $(or $(CSB_VERSION), $(shell grep 'github.com/cloudfoundry/cloud-service-broker' go.mod | grep -v replace | awk '{print $$NF}' | sed -e 's/v//'))
 CSB_RELEASE_VERSION := $(CSB_VERSION) # this doesnt work well if we did make latest-csb.
 
@@ -66,8 +68,17 @@ endif
 
 ###### Targets ################################################################
 
+.PHONY: deps-go-binary
+deps-go-binary:
+ifeq ($(SKIP_GO_VERSION_CHECK),)
+	@@if [ "$$($(GO) version | awk '{print $$3}')" != "${GO-VER}" ]; then \
+		echo "Go version does not match: expected: ${GO-VER}, got $$($(GO) version | awk '{print $$3}')"; \
+		exit 1; \
+	fi
+endif
+
 .PHONY: build
-build: $(IAAS)-services-*.brokerpak ## build brokerpak
+build: deps-go-binary $(IAAS)-services-*.brokerpak ## build brokerpak
 
 $(IAAS)-services-*.brokerpak: *.yml terraform/*/*/*.tf terraform/*/*/*/*.tf | $(PAK_CACHE)
 	$(RUN_CSB) pak build


### PR DESCRIPTION
- new check only prints when there is an error
- new check does not allow substring matches

[#181960182](https://www.pivotaltracker.com/story/show/181960182)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

