### PR TITLE
feat: prevent region update for s3

### DIFF
--- a/aws-s3-bucket.yml
+++ b/aws-s3-bucket.yml
@@ -69,6 +69,7 @@ provision:
           - us-west-2
           - eu-west-1
         pattern: ^[a-z][a-z0-9-]+$
+      prohibit_update: true
     - field_name: aws_access_key_id
       type: string
       details: AWS access key

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -1,6 +1,7 @@
 ## Release notes for next release:
 
 ### New feature:
+- S3: region updates for existing buckets are now blocked by the broker resulting in faster feedback and improved error message.
 
 ### Fix:
 - minimum constraints on MySQL and PostreSQL storage_gb are now enforced


### PR DESCRIPTION
s3 bucket region cannot be changed, this will result in faster
feedback and better error message

[#182259915](https://www.pivotaltracker.com/story/show/182259915)

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

