### PR TITLE
chore: replace 'interface{}' with 'any'

### DIFF
--- a/acceptance-tests/apps/dynamodbapp/internal/app/app.go
+++ b/acceptance-tests/apps/dynamodbapp/internal/app/app.go
@@ -47,7 +47,7 @@ func aliveness(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func fail(w http.ResponseWriter, code int, format string, a ...interface{}) {
+func fail(w http.ResponseWriter, code int, format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	log.Println(msg)
 	http.Error(w, msg, code)

--- a/acceptance-tests/apps/postgresqlapp/internal/app/app.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/app.go
@@ -61,7 +61,7 @@ func schemaName(r *http.Request) (string, error) {
 	}
 }
 
-func fail(w http.ResponseWriter, code int, format string, a ...interface{}) {
+func fail(w http.ResponseWriter, code int, format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	log.Println(msg)
 	http.Error(w, msg, code)

--- a/acceptance-tests/apps/s3app/internal/app/app.go
+++ b/acceptance-tests/apps/s3app/internal/app/app.go
@@ -49,7 +49,7 @@ func aliveness(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func fail(w http.ResponseWriter, code int, format string, a ...interface{}) {
+func fail(w http.ResponseWriter, code int, format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	log.Println(msg)
 	http.Error(w, msg, code)

--- a/acceptance-tests/dynamodb_test.go
+++ b/acceptance-tests/dynamodb_test.go
@@ -45,9 +45,9 @@ var _ = Describe("DynamoDB", Label("dynamodb"), func() {
 	})
 })
 
-func config() interface{} {
-	return map[string]interface{}{
-		"attributes": []map[string]interface{}{
+func config() any {
+	return map[string]any{
+		"attributes": []map[string]any{
 			{
 				"name": "id",
 				"type": "S",
@@ -64,7 +64,7 @@ func config() interface{} {
 		"hash_key":   "id",
 		"range_key":  "value",
 		"table_name": random.Name(random.WithPrefix("csb", "dynamodb")),
-		"global_secondary_indexes": []map[string]interface{}{
+		"global_secondary_indexes": []map[string]any{
 			{
 				"name":               "KeyIndex",
 				"hash_key":           "key",

--- a/acceptance-tests/helpers/apps/http.go
+++ b/acceptance-tests/helpers/apps/http.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func (a *App) GET(format string, s ...interface{}) string {
+func (a *App) GET(format string, s ...any) string {
 	url := a.urlf(format, s...)
 	fmt.Fprintf(GinkgoWriter, "HTTP GET: %s\n", url)
 	response, err := http.Get(url)
@@ -25,7 +25,7 @@ func (a *App) GET(format string, s ...interface{}) string {
 	return string(data)
 }
 
-func (a *App) PUT(data, format string, s ...interface{}) {
+func (a *App) PUT(data, format string, s ...any) {
 	url := a.urlf(format, s...)
 	fmt.Fprintf(GinkgoWriter, "HTTP PUT: %s\n", url)
 	fmt.Fprintf(GinkgoWriter, "Sending data: %s\n", data)
@@ -37,7 +37,7 @@ func (a *App) PUT(data, format string, s ...interface{}) {
 	Expect(response).To(HaveHTTPStatus(http.StatusCreated, http.StatusOK))
 }
 
-func (a *App) DELETE(format string, s ...interface{}) {
+func (a *App) DELETE(format string, s ...any) {
 	url := a.urlf(format, s...)
 	fmt.Fprintf(GinkgoWriter, "HTTP DELETE: %s\n", url)
 	request, err := http.NewRequest(http.MethodDelete, url, nil)
@@ -48,7 +48,7 @@ func (a *App) DELETE(format string, s ...interface{}) {
 	Expect(response).To(HaveHTTPStatus(http.StatusGone, http.StatusNoContent))
 }
 
-func (a *App) urlf(format string, s ...interface{}) string {
+func (a *App) urlf(format string, s ...any) string {
 	base := a.URL
 	path := fmt.Sprintf(format, s...)
 	switch {

--- a/acceptance-tests/helpers/apps/setenv.go
+++ b/acceptance-tests/helpers/apps/setenv.go
@@ -9,7 +9,7 @@ import (
 
 type EnvVar struct {
 	Name  string
-	Value interface{}
+	Value any
 }
 
 func (a *App) SetEnv(env ...EnvVar) {

--- a/acceptance-tests/helpers/bindings/credential.go
+++ b/acceptance-tests/helpers/bindings/credential.go
@@ -10,21 +10,21 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func (b *Binding) Credential() interface{} {
+func (b *Binding) Credential() any {
 	out, _ := cf.Run("app", "--guid", b.appName)
 	env, _ := cf.Run("curl", fmt.Sprintf("/v3/apps/%s/env", strings.TrimSpace(out)))
 
 	var receiver struct {
-		Services map[string]interface{} `jsonry:"system_env_json.VCAP_SERVICES"`
+		Services map[string]any `jsonry:"system_env_json.VCAP_SERVICES"`
 	}
 	Expect(jsonry.Unmarshal([]byte(env), &receiver)).NotTo(HaveOccurred())
 
 	for _, bindings := range receiver.Services {
-		Expect(bindings).To(BeAssignableToTypeOf([]interface{}{}))
-		for _, bnd := range bindings.([]interface{}) {
-			if n, ok := bnd.(map[string]interface{})["name"]; ok && n == b.name {
+		Expect(bindings).To(BeAssignableToTypeOf([]any{}))
+		for _, bnd := range bindings.([]any) {
+			if n, ok := bnd.(map[string]any)["name"]; ok && n == b.name {
 				Expect(bnd).To(HaveKey("credentials"))
-				return bnd.(map[string]interface{})["credentials"]
+				return bnd.(map[string]any)["credentials"]
 			}
 		}
 	}

--- a/acceptance-tests/helpers/servicekeys/get.go
+++ b/acceptance-tests/helpers/servicekeys/get.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func (s *ServiceKey) Get(receiver interface{}) {
+func (s *ServiceKey) Get(receiver any) {
 	Expect(reflect.ValueOf(receiver).Kind()).To(Equal(reflect.Ptr), "receiver must be a pointer")
 	out, _ := cf.Run("service-key", s.serviceInstanceName, s.name)
 	start := strings.Index(out, "{")
@@ -18,7 +18,7 @@ func (s *ServiceKey) Get(receiver interface{}) {
 
 	if cf.Version() == cf.VersionV8 {
 		var wrapper struct {
-			Credentials interface{} `json:"credentials"`
+			Credentials any `json:"credentials"`
 		}
 		err := json.Unmarshal(data, &wrapper)
 		Expect(err).NotTo(HaveOccurred())

--- a/acceptance-tests/helpers/services/create.go
+++ b/acceptance-tests/helpers/services/create.go
@@ -82,7 +82,7 @@ func WithBroker(broker *brokers.Broker) Option {
 	}
 }
 
-func WithParameters(parameters interface{}) Option {
+func WithParameters(parameters any) Option {
 	return func(c *config) {
 		switch p := parameters.(type) {
 		case string:


### PR DESCRIPTION
Go 1.18 introduced the alternative of 'any' for the rather awkward
'interface{}'. Since this came out we have been using a mixture in this
project. This PR updates code (except generated code) to consistently
use `any` since it's easier to type and to understand.

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

