### PR TITLE
feat: s3 bucket ownership controls can now be set

### DIFF
--- a/aws-s3-bucket.yml
+++ b/aws-s3-bucket.yml
@@ -71,6 +71,14 @@ provision:
           - eu-west-1
         pattern: ^[a-z][a-z0-9-]+$
       prohibit_update: true
+    - field_name: boc_object_ownership
+      type: string
+      details: S3 Bucket Ownership Controls (see https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html)
+      enum:
+        BucketOwnerPreferred: BucketOwnerPreferred
+        ObjectWriter: ObjectWriter
+        BucketOwnerEnforced: BucketOwnerEnforced
+      default: BucketOwnerEnforced
     - field_name: aws_access_key_id
       type: string
       details: AWS access key

--- a/docs/aws-installation.md
+++ b/docs/aws-installation.md
@@ -28,6 +28,7 @@ The AWS account represented by the access key needs the following permission pol
                     "s3:PutBucketLogging",
                     "s3:PutBucketPolicy",
                     "s3:PutBucketTagging",
+                    "s3:PutBucketOwnershipControls",
                     "s3:GetObject",
                     "s3:ListBucket",
                     "iam:CreateAccessKey",

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -3,7 +3,8 @@
 ### Features
 - region property as a text field instead of an enumerated enabling selection of any region available in the Cloud Provider
 - S3: region updates for existing buckets are now blocked by the broker resulting in faster feedback and improved error message.
-- S3: ACL can now be specified on creation/updated if the plan does not specify a value for it. Previously it was a plan-only input and as such could only be specified in the plan definition.
+- S3: ACL can now be specified on creation/update if the plan does not specify a value for it. Previously it was a plan-only input and as such could only be specified in the plan definition.
+- S3: Bucket Ownership controls can now be specified in a plan or on creation/update if the plan does not specify a value for it.
 - Beta tag: all service offerings tagged as beta and will not be displayed by default in the marketplace. Set the environment variable `GSB_COMPATIBILITY_ENABLE_BETA_SERVICES` to true to enable them. 
 
 ### Fix:

--- a/integration-tests/s3_test.go
+++ b/integration-tests/s3_test.go
@@ -127,6 +127,17 @@ var _ = Describe("S3", Label("s3"), func() {
 
 				Expect(err).To(MatchError(ContainSubstring("region: Does not match pattern '^[a-z][a-z0-9-]+$'")))
 			})
+			DescribeTable("should ensure enum values are validated",
+				func(params map[string]any, property string) {
+					_, err := broker.Provision(s3ServiceName, customS3Plan["name"].(string), params)
+
+					Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("%[1]s: %[1]s must be one of the following", property))))
+				},
+
+				Entry("update boc_object_ownership", map[string]any{"boc_object_ownership": "invalidValue"}, "boc_object_ownership"),
+				Entry("update acl", map[string]any{"acl": "invalidValue"}, "acl"),
+			)
+
 		})
 	})
 

--- a/integration-tests/s3_test.go
+++ b/integration-tests/s3_test.go
@@ -83,6 +83,7 @@ var _ = Describe("S3", Label("s3"), func() {
 					HaveKeyWithValue("labels", HaveKeyWithValue("pcf-instance-id", instanceID)),
 					HaveKeyWithValue("region", "us-west-2"),
 					HaveKeyWithValue("acl", "private"),
+					HaveKeyWithValue("boc_object_ownership", "BucketOwnerEnforced"),
 					HaveKeyWithValue("aws_access_key_id", awsAccessKeyID),
 					HaveKeyWithValue("aws_secret_access_key", awsSecretAccessKey),
 				),

--- a/integration-tests/s3_test.go
+++ b/integration-tests/s3_test.go
@@ -95,6 +95,7 @@ var _ = Describe("S3", Label("s3"), func() {
 				"enable_versioning":     true,
 				"region":                "eu-west-1",
 				"acl":                   "public-read",
+				"boc_object_ownership":  "BucketOwnerPreferred",
 				"aws_access_key_id":     "fake-aws-access-key-id",
 				"aws_secret_access_key": "fake-aws-secret-access-key",
 			})
@@ -107,6 +108,7 @@ var _ = Describe("S3", Label("s3"), func() {
 					HaveKeyWithValue("labels", HaveKeyWithValue("pcf-instance-id", instanceID)),
 					HaveKeyWithValue("region", "eu-west-1"),
 					HaveKeyWithValue("acl", "public-read"),
+					HaveKeyWithValue("boc_object_ownership", "BucketOwnerPreferred"),
 					HaveKeyWithValue("aws_access_key_id", "fake-aws-access-key-id"),
 					HaveKeyWithValue("aws_secret_access_key", "fake-aws-secret-access-key"),
 				),
@@ -147,6 +149,7 @@ var _ = Describe("S3", Label("s3"), func() {
 			Entry("update aws_access_key_id", map[string]any{"aws_access_key_id": "another-aws_access_key_id"}),
 			Entry("update aws_secret_access_key", map[string]any{"aws_secret_access_key": "another-aws_secret_access_key"}),
 			Entry("update acl", map[string]any{"acl": "public-read"}),
+			Entry("update boc_object_ownership", map[string]any{"boc_object_ownership": "BucketOwnerPreferred"}),
 		)
 
 		DescribeTable("should prevent updating properties flagged as `prohibit_update` because it can result in the recreation of the service instance and lost data",

--- a/terraform/s3/provision/main.tf
+++ b/terraform/s3/provision/main.tf
@@ -26,3 +26,11 @@ resource "aws_s3_bucket" "b" {
     prevent_destroy = true
   }
 }
+
+resource "aws_s3_bucket_ownership_controls" "example" {
+  bucket = aws_s3_bucket.b.id
+
+  rule {
+    object_ownership = var.boc_object_ownership
+  }
+}

--- a/terraform/s3/provision/variables.tf
+++ b/terraform/s3/provision/variables.tf
@@ -16,3 +16,4 @@ variable "bucket_name" { type = string }
 variable "acl" { type = string }
 variable "labels" { type = map(any) }
 variable "enable_versioning" { type = bool }
+variable "boc_object_ownership" { type = string }


### PR DESCRIPTION
This allows plans to be defined with bucket ownership controls
or if not defined in the plan, the value can be set at provision
or update.

[#182479512](https://www.pivotaltracker.com/story/show/182479512)

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

