### PR TITLE
fix: boc match the default value to aws console

### DIFF
--- a/aws-s3-bucket.yml
+++ b/aws-s3-bucket.yml
@@ -78,7 +78,7 @@ provision:
         BucketOwnerPreferred: BucketOwnerPreferred
         ObjectWriter: ObjectWriter
         BucketOwnerEnforced: BucketOwnerEnforced
-      default: BucketOwnerEnforced
+      default: ObjectWriter
     - field_name: aws_access_key_id
       type: string
       details: AWS access key

--- a/integration-tests/s3_test.go
+++ b/integration-tests/s3_test.go
@@ -83,7 +83,7 @@ var _ = Describe("S3", Label("s3"), func() {
 					HaveKeyWithValue("labels", HaveKeyWithValue("pcf-instance-id", instanceID)),
 					HaveKeyWithValue("region", "us-west-2"),
 					HaveKeyWithValue("acl", "private"),
-					HaveKeyWithValue("boc_object_ownership", "BucketOwnerEnforced"),
+					HaveKeyWithValue("boc_object_ownership", "ObjectWriter"),
 					HaveKeyWithValue("aws_access_key_id", awsAccessKeyID),
 					HaveKeyWithValue("aws_secret_access_key", awsSecretAccessKey),
 				),


### PR DESCRIPTION
Whilst the recommended setting is BucketOwnerEnforced
this causes updates to ACL to fail. We should match the console
default of ObjectWriter.

[#182479512](https://www.pivotaltracker.com/story/show/182479512)

### Checklist:

* [ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

