### PR TITLE
feat: s3 allow server side encryption to be configured

### DIFF
--- a/aws-s3-bucket.yml
+++ b/aws-s3-bucket.yml
@@ -103,6 +103,18 @@ provision:
       type: boolean
       details: Whether Amazon S3 should restrict public bucket policies for the bucket.
       default: false
+    - field_name: sse_default_kms_master_key_id
+      type: string
+      details: The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_default_algorithm` as `aws:kms`.
+      default: null
+    - field_name: sse_default_algorithm
+      type: string
+      details: The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`. (see https://docs.aws.amazon.com/AmazonS3/latest/userguide/serv-side-encryption.html)
+      default: null
+    - field_name: sse_bucket_key_enabled
+      type: boolean
+      details: Whether or not to use Amazon S3 Bucket Keys for SSE-KMS. (see https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html).
+      default: false
   computed_inputs:
   - name: labels
     default: ${json.marshal(request.default_labels)}

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -6,6 +6,7 @@
 - S3: ACL can now be specified on creation/update if the plan does not specify a value for it. Previously it was a plan-only input and as such could only be specified in the plan definition.
 - S3: Bucket Ownership controls can now be specified in a plan or on creation/update if the plan does not specify a value for it.
 - S3: Blocking public access to Amazon S3 storage. This feature provides settings for buckets to help manage public access to Amazon S3 resources. S3 Block Public Access settings override policies and permissions so that it is possible to limit public access to these resources.
+- S3: Server Side encryption can now be enabled and configured. This feature provides settings for configuring encryption of data in an S3 bucket.
 - Beta tag: all service offerings tagged as beta and will not be displayed by default in the marketplace. Set the environment variable `GSB_COMPATIBILITY_ENABLE_BETA_SERVICES` to true to enable them. 
 
 ### Fix:

--- a/integration-tests/s3_test.go
+++ b/integration-tests/s3_test.go
@@ -88,6 +88,9 @@ var _ = Describe("S3", Label("s3"), func() {
 					HaveKeyWithValue("pab_block_public_policy", false),
 					HaveKeyWithValue("pab_ignore_public_acls", false),
 					HaveKeyWithValue("pab_restrict_public_buckets", false),
+					HaveKeyWithValue("sse_default_kms_master_key_id", BeNil()),
+					HaveKeyWithValue("sse_default_algorithm", BeNil()),
+					HaveKeyWithValue("sse_bucket_key_enabled", false),
 					HaveKeyWithValue("aws_access_key_id", awsAccessKeyID),
 					HaveKeyWithValue("aws_secret_access_key", awsSecretAccessKey),
 				),
@@ -96,14 +99,17 @@ var _ = Describe("S3", Label("s3"), func() {
 
 		It("should allow setting properties not defined in the plan", func() {
 			instanceID, err := broker.Provision(s3ServiceName, customS3Plan["name"].(string), map[string]any{
-				"bucket_name":           "fake-bucket-name",
-				"enable_versioning":     true,
-				"region":                "eu-west-1",
-				"acl":                   "public-read",
-				"boc_object_ownership":  "BucketOwnerPreferred",
-				"pab_block_public_acls": true,
-				"aws_access_key_id":     "fake-aws-access-key-id",
-				"aws_secret_access_key": "fake-aws-secret-access-key",
+				"bucket_name":                   "fake-bucket-name",
+				"enable_versioning":             true,
+				"region":                        "eu-west-1",
+				"acl":                           "public-read",
+				"boc_object_ownership":          "BucketOwnerPreferred",
+				"pab_block_public_acls":         true,
+				"sse_default_kms_master_key_id": "key-arn",
+				"sse_bucket_key_enabled":        true,
+				"sse_default_algorithm":         "aws:kms",
+				"aws_access_key_id":             "fake-aws-access-key-id",
+				"aws_secret_access_key":         "fake-aws-secret-access-key",
 			})
 
 			Expect(err).NotTo(HaveOccurred())
@@ -119,6 +125,9 @@ var _ = Describe("S3", Label("s3"), func() {
 					HaveKeyWithValue("pab_block_public_policy", false),
 					HaveKeyWithValue("pab_ignore_public_acls", false),
 					HaveKeyWithValue("pab_restrict_public_buckets", false),
+					HaveKeyWithValue("sse_default_kms_master_key_id", "key-arn"),
+					HaveKeyWithValue("sse_default_algorithm", "aws:kms"),
+					HaveKeyWithValue("sse_bucket_key_enabled", true),
 					HaveKeyWithValue("aws_access_key_id", "fake-aws-access-key-id"),
 					HaveKeyWithValue("aws_secret_access_key", "fake-aws-secret-access-key"),
 				),
@@ -175,6 +184,9 @@ var _ = Describe("S3", Label("s3"), func() {
 			Entry("update pab_block_public_policy", map[string]any{"pab_block_public_policy": true}),
 			Entry("update pab_ignore_public_acls", map[string]any{"pab_ignore_public_acls": true}),
 			Entry("update pab_restrict_public_buckets", map[string]any{"pab_restrict_public_buckets": true}),
+			Entry("update sse apply_server_side_encryption_by_default block", map[string]any{"sse_default_kms_master_key_id": "key-arn", "sse_default_algorithm": "aws:kms", "sse_bucket_key_enabled": true}),
+			Entry("update sse_default_algorithm", map[string]any{"sse_default_algorithm": "AES256"}),
+			Entry("update sse_bucket_key_enabled", map[string]any{"sse_bucket_key_enabled": true}),
 		)
 
 		DescribeTable("should prevent updating properties flagged as `prohibit_update` because it can result in the recreation of the service instance and lost data",

--- a/terraform/s3/provision/main.tf
+++ b/terraform/s3/provision/main.tf
@@ -27,7 +27,7 @@ resource "aws_s3_bucket" "b" {
   }
 }
 
-resource "aws_s3_bucket_ownership_controls" "example" {
+resource "aws_s3_bucket_ownership_controls" "bucket_ownership_controls" {
   bucket = aws_s3_bucket.b.id
 
   rule {
@@ -42,4 +42,21 @@ resource "aws_s3_bucket_public_access_block" "bucket_public_access_block" {
   block_public_policy     = var.pab_block_public_policy
   ignore_public_acls      = var.pab_ignore_public_acls
   restrict_public_buckets = var.pab_restrict_public_buckets
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "server_side_encryption_configuration" {
+  count = (var.sse_default_algorithm == null && var.sse_bucket_key_enabled == false) ? 0 : 1
+  bucket = aws_s3_bucket.b.bucket
+
+  rule {
+    dynamic "apply_server_side_encryption_by_default" {
+      for_each = var.sse_default_algorithm[*]
+      content {
+        kms_master_key_id = var.sse_default_kms_master_key_id
+        sse_algorithm     = var.sse_default_algorithm
+      }
+    }
+
+    bucket_key_enabled = var.sse_bucket_key_enabled
+  }
 }

--- a/terraform/s3/provision/main.tf
+++ b/terraform/s3/provision/main.tf
@@ -45,7 +45,7 @@ resource "aws_s3_bucket_public_access_block" "bucket_public_access_block" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "server_side_encryption_configuration" {
-  count = (var.sse_default_algorithm == null && var.sse_bucket_key_enabled == false) ? 0 : 1
+  count = (var.sse_default_algorithm != null || var.sse_bucket_key_enabled != false) ? 1 : 0
   bucket = aws_s3_bucket.b.bucket
 
   rule {

--- a/terraform/s3/provision/variables.tf
+++ b/terraform/s3/provision/variables.tf
@@ -23,3 +23,9 @@ variable "pab_block_public_acls" { type = bool }
 variable "pab_block_public_policy" { type = bool }
 variable "pab_ignore_public_acls" { type = bool }
 variable "pab_restrict_public_buckets" { type = bool }
+
+# Resource aws_s3_bucket_server_side_encryption_configuration
+variable "sse_default_kms_master_key_id" { type = string }
+variable "sse_default_algorithm" { type = string }
+variable "sse_bucket_key_enabled" { type = string }
+


### PR DESCRIPTION
This allows the server_side_encryption resource to be created
if a user specifies in a plan/provision request.

[#182296596](https://www.pivotaltracker.com/story/show/182296596)

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

