### PR TITLE
feat: "verify-ca" when connecting to PostgreSQL database

### DIFF
--- a/acceptance-tests/apps/postgresqlapp/internal/app/app.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/app.go
@@ -36,7 +36,7 @@ func aliveness(w http.ResponseWriter, r *http.Request) {
 }
 
 func connect(uri string) *sql.DB {
-	db, err := sql.Open("pgx", fmt.Sprintf("%s?sslmode=verify-ca", uri))
+	db, err := sql.Open("pgx", fmt.Sprintf("%s?sslmode=verify-full", uri))
 	if err != nil {
 		log.Fatalf("failed to connect to database: %s", err)
 	}

--- a/acceptance-tests/apps/postgresqlapp/internal/app/app.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/app.go
@@ -36,7 +36,7 @@ func aliveness(w http.ResponseWriter, r *http.Request) {
 }
 
 func connect(uri string) *sql.DB {
-	db, err := sql.Open("pgx", uri)
+	db, err := sql.Open("pgx", fmt.Sprintf("%s?sslmode=verify-ca", uri))
 	if err != nil {
 		log.Fatalf("failed to connect to database: %s", err)
 	}

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -8,6 +8,7 @@
 - S3: Blocking public access to Amazon S3 storage. This feature provides settings for buckets to help manage public access to Amazon S3 resources. S3 Block Public Access settings override policies and permissions so that it is possible to limit public access to these resources.
 - S3: Server Side encryption can now be enabled and configured. This feature provides settings for configuring encryption of data in an S3 bucket.
 - Beta tag: all service offerings tagged as beta and will not be displayed by default in the marketplace. Set the environment variable `GSB_COMPATIBILITY_ENABLE_BETA_SERVICES` to true to enable them. 
+- PostgreSQL: when creating a binding, the PostgreSQL connection will be secured via the "verify-ca" PosgreSQL configuration. This will require the AWS certificate bundle to be installed.
 
 ### Fix:
 - minimum constraints on MySQL and PostreSQL storage_gb are now enforced

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -8,7 +8,7 @@
 - S3: Blocking public access to Amazon S3 storage. This feature provides settings for buckets to help manage public access to Amazon S3 resources. S3 Block Public Access settings override policies and permissions so that it is possible to limit public access to these resources.
 - S3: Server Side encryption can now be enabled and configured. This feature provides settings for configuring encryption of data in an S3 bucket.
 - Beta tag: all service offerings tagged as beta and will not be displayed by default in the marketplace. Set the environment variable `GSB_COMPATIBILITY_ENABLE_BETA_SERVICES` to true to enable them. 
-- PostgreSQL: when creating a binding, the PostgreSQL connection will be secured via the "verify-ca" PosgreSQL configuration. This will require the AWS certificate bundle to be installed.
+- PostgreSQL: when creating a binding, by default the PostgreSQL connection will be secured via the "verify-full" PosgreSQL configuration. This will require the AWS certificate bundle to be installed, or it can be disabled by setting "use_tls=false"
 
 ### Fix:
 - minimum constraints on MySQL and PostreSQL storage_gb are now enforced

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0
 	golang.org/x/tools v0.1.11-0.20220513221640-090b14e8501f
+	gopkg.in/yaml.v3 v3.0.1
 	honnef.co/go/tools v0.3.2
 )
 
@@ -101,7 +102,6 @@ require (
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/driver/mysql v1.3.4 // indirect
 	gorm.io/driver/sqlite v1.3.6 // indirect
 	gorm.io/gorm v1.23.8 // indirect

--- a/terraform/postgresql/bind/provider.tf
+++ b/terraform/postgresql/bind/provider.tf
@@ -19,5 +19,5 @@ provider "postgresql" {
   password  = var.admin_password
   superuser = false
   database  = var.db_name
-  sslmode   = "verify-ca"
+  sslmode   = var.use_tls ? "verify-full" : "prefer"
 }

--- a/terraform/postgresql/bind/provider.tf
+++ b/terraform/postgresql/bind/provider.tf
@@ -19,5 +19,5 @@ provider "postgresql" {
   password  = var.admin_password
   superuser = false
   database  = var.db_name
-  sslmode   = var.use_tls ? "require" : "disable"
+  sslmode   = "verify-ca"
 }


### PR DESCRIPTION
- AWS enables TLS on PostgreSQL databases
- The Terraform provider that creates bindings should therefore protect
against "machine in the middle" attacks by validating the CA
- This will require the AWS certificate bundle to have been installed,
but it's a fair bet that folks do this anyway.
- acceptance tests have also been updated to verify TLS via the CA

[#182758757](https://www.pivotaltracker.com/story/show/182758757)

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

