### PR TITLE
feat(postgresql): new "provider_verify_certificate"

### DIFF
--- a/aws-postgresql.yml
+++ b/aws-postgresql.yml
@@ -107,7 +107,11 @@ provision:
   - field_name: use_tls
     type: boolean
     details: Use TLS for connection
-    default: true      
+    default: true
+  - field_name: provider_verify_certificate
+    type: boolean
+    details: Whether PostgreSQL Terraform provider should validate the server certificate. The AWS certificate bundle must be installed.
+    default: true
   - field_name: storage_autoscale
     type: boolean
     default: false
@@ -317,6 +321,9 @@ provision:
   - field_name: use_tls
     type: boolean
     details: Using TLS for connection
+  - field_name: provider_verify_certificate
+    type: boolean
+    details: Whether PostgreSQL Terraform provider should validate the server certificate. The AWS certificate bundle must be installed.
 bind:
   plan_inputs: []
   user_inputs: []
@@ -345,6 +352,10 @@ bind:
     type: boolean
     default: ${instance.details["use_tls"]}
     overwrite: true    
+  - name: provider_verify_certificate
+    type: boolean
+    default: ${instance.details["provider_verify_certificate"]}
+    overwrite: true
   template_refs:
     outputs: ./terraform/postgresql/bind/outputs.tf
     provider: ./terraform/postgresql/bind/provider.tf
@@ -368,35 +379,35 @@ examples:
 - name: small
   description: Create a small PostgreSQL instance
   plan_id: ffc51616-228b-41bd-bed1-d601c18d58f5
-  provision_params: { "publicly_accessible": true, "use_tls": false }
+  provision_params: { "publicly_accessible": true, "provider_verify_certificate": false }
   bind_params: {}
 - name: medium
   description: Create a medium PostgreSQL instance
   plan_id: e64d07f9-ceb2-40a6-abd9-391047fa3cf5
-  provision_params: { "publicly_accessible": true, "use_tls": false }
+  provision_params: { "publicly_accessible": true, "provider_verify_certificate": false }
   bind_params: {}
 - name: large
   description: Create a large PostgreSQL instance
   plan_id: 48baef10-a14c-4ae1-aab5-25f26eba941a
-  provision_params: { "publicly_accessible": true, "use_tls": false }
+  provision_params: { "publicly_accessible": true, "provider_verify_certificate": false }
   bind_params: {}
 - name: medium-multiaz
   description: Create a medium multiaz PostgreSQL instance
   plan_id: e64d07f9-ceb2-40a6-abd9-391047fa3cf5
-  provision_params: { "publicly_accessible": true, "multi_az": true, "use_tls": false }
+  provision_params: { "publicly_accessible": true, "multi_az": true, "provider_verify_certificate": false }
   bind_params: {}
 - name: small-encrypted
   description: Create a small PostgreSQL instance with encrypted storage
   plan_id: ffc51616-228b-41bd-bed1-d601c18d58f5
-  provision_params: { "storage_encrypted": true, "publicly_accessible": true, "use_tls": false }
+  provision_params: { "storage_encrypted": true, "publicly_accessible": true, "provider_verify_certificate": false }
   bind_params: {}
 - name: small-disable-upgrades
   description: Create a small PostgreSQL instance with disabled upgrades
   plan_id: ffc51616-228b-41bd-bed1-d601c18d58f5
-  provision_params: { "allow_major_version_upgrade": false, "auto_minor_version_upgrade": false, "publicly_accessible": true, "use_tls": false }
+  provision_params: { "allow_major_version_upgrade": false, "auto_minor_version_upgrade": false, "publicly_accessible": true, "provider_verify_certificate": false }
   bind_params: {}
 - name: small-with-maintenance-window
   description: Create a small PostgreSQL instance with encrypted storage
   plan_id: ffc51616-228b-41bd-bed1-d601c18d58f5
-  provision_params: { "maintenance_day": "Thu", "maintenance_start_hour": "15", "maintenance_start_min": "30", "maintenance_end_hour": "17", "maintenance_end_min": "00", "publicly_accessible": true, "use_tls": false }
+  provision_params: { "maintenance_day": "Thu", "maintenance_start_hour": "15", "maintenance_start_min": "30", "maintenance_end_hour": "17", "maintenance_end_min": "00", "publicly_accessible": true, "provider_verify_certificate": false }
   bind_params: {}

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -9,6 +9,7 @@
 - S3: Server Side encryption can now be enabled and configured. This feature provides settings for configuring encryption of data in an S3 bucket.
 - Beta tag: all service offerings tagged as beta and will not be displayed by default in the marketplace. Set the environment variable `GSB_COMPATIBILITY_ENABLE_BETA_SERVICES` to true to enable them. 
 - PostgreSQL: when creating a binding, by default the PostgreSQL connection will be secured via the "verify-full" PosgreSQL configuration. This will require the AWS certificate bundle to be installed, or it can be disabled by setting "use_tls=false"
+- PostgreSQL: a new "provider_verify_certificate" property allows for the PostgreSQL Terraform provider to skip the verification of the server certificate.
 
 ### Fix:
 - minimum constraints on MySQL and PostreSQL storage_gb are now enforced

--- a/terraform/postgresql/bind/provider.tf
+++ b/terraform/postgresql/bind/provider.tf
@@ -19,5 +19,5 @@ provider "postgresql" {
   password  = var.admin_password
   superuser = false
   database  = var.db_name
-  sslmode   = var.use_tls ? "verify-full" : "prefer"
+  sslmode   = var.provider_verify_certificate ? "verify-full" : "require"
 }

--- a/terraform/postgresql/bind/variables.tf
+++ b/terraform/postgresql/bind/variables.tf
@@ -18,3 +18,4 @@ variable "port" { type = number }
 variable "admin_username" { type = string }
 variable "admin_password" { type = string }
 variable "use_tls" { type = bool }
+variable "provider_verify_certificate" { type = bool }

--- a/terraform/postgresql/provision/outputs.tf
+++ b/terraform/postgresql/provision/outputs.tf
@@ -18,6 +18,7 @@ output "port" { value = local.ports[var.engine] }
 output "username" { value = aws_db_instance.db_instance.username }
 output "password" { value = aws_db_instance.db_instance.password }
 output "use_tls" { value = var.use_tls }
+output "provider_verify_certificate" { value = var.provider_verify_certificate }
 output "status" { value = format("created db %s (id: %s) on server %s URL: https://%s.console.aws.amazon.com/rds/home?region=%s#database:id=%s;is-cluster=false",
   aws_db_instance.db_instance.name,
   aws_db_instance.db_instance.id,

--- a/terraform/postgresql/provision/variables.tf
+++ b/terraform/postgresql/provision/variables.tf
@@ -34,3 +34,4 @@ variable "allow_major_version_upgrade" { type = bool }
 variable "auto_minor_version_upgrade" { type = bool }
 variable "maintenance_window" { type = string }
 variable "use_tls" { type = bool }
+variable "provider_verify_certificate" { type = bool }


### PR DESCRIPTION
This fixes a problem introduced by commit fdf0e23436db762adaa6a95da48f3932a75740b7

AWS PostgreSQL instances will have TLS available by default. We had
previously conflated two concept:
1) Whether the PostgreSQL Terraform provider should attempt to validate
the server certificate. To do this it needs the AWS certificate bundle.
It's typical to have the AWS certificate bundle installed, but some
environments might not. In this case the provider should still connect
over TLS, but not validate the certificate.
2) Whether the server should accept non-TLS connections. This is implied
by the "use_tls" property, but is not implemented correctly yet, as in
all cases the server will currently accept TLS and non-TLS connections.

This PR introduces a new property "provider_verify_certificate" which is
true by default, and can be set to false in order to disable server
certificate checking by the provider.

[#182758757](https://www.pivotaltracker.com/story/show/182758757)

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

