### PR TITLE
feat: server should reject non-TLS connections by default

### DIFF
--- a/aws-postgresql.yml
+++ b/aws-postgresql.yml
@@ -104,9 +104,9 @@ provision:
     type: boolean
     details: Indicates an existing PostgreSQL instnace should be subsumed
   user_inputs:
-  - field_name: use_tls
+  - field_name: require_ssl
     type: boolean
-    details: Use TLS for connection
+    details: Require that connections use SSL. Note that if "parameter_group_name" is specified then the "require_ssl" parameter will not take effect.
     default: true
   - field_name: provider_verify_certificate
     type: boolean
@@ -318,9 +318,9 @@ provision:
   - field_name: password
     type: string
     details: The password to authenticate to the database instance.
-  - field_name: use_tls
+  - field_name: require_ssl
     type: boolean
-    details: Using TLS for connection
+    details: Require that connections use SSL
   - field_name: provider_verify_certificate
     type: boolean
     details: Whether PostgreSQL Terraform provider should validate the server certificate. The AWS certificate bundle must be installed.
@@ -348,10 +348,10 @@ bind:
     type: string
     default: ${instance.details["password"]}
     overwrite: true
-  - name: use_tls
+  - name: require_ssl
     type: boolean
-    default: ${instance.details["use_tls"]}
-    overwrite: true    
+    default: ${instance.details["require_ssl"]}
+    overwrite: true
   - name: provider_verify_certificate
     type: boolean
     default: ${instance.details["provider_verify_certificate"]}

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -10,6 +10,7 @@
 - Beta tag: all service offerings tagged as beta and will not be displayed by default in the marketplace. Set the environment variable `GSB_COMPATIBILITY_ENABLE_BETA_SERVICES` to true to enable them. 
 - PostgreSQL: when creating a binding, by default the PostgreSQL connection will be secured via the "verify-full" PosgreSQL configuration. This will require the AWS certificate bundle to be installed, or it can be disabled by setting "use_tls=false"
 - PostgreSQL: a new "provider_verify_certificate" property allows for the PostgreSQL Terraform provider to skip the verification of the server certificate.
+- PostgreSQL: server rejects non-SSL connections by default. Renamed "use_tls" to "require_ssl". The "require_ssl" property is true by defalt, and will make the server require SSL connections. When false, the server will accept SSL and non-SSL connections.
 
 ### Fix:
 - minimum constraints on MySQL and PostreSQL storage_gb are now enforced

--- a/terraform/postgresql/bind/outputs.tf
+++ b/terraform/postgresql/bind/outputs.tf
@@ -15,19 +15,23 @@
 output "username" { value = postgresql_role.new_user.name }
 output "password" { value = postgresql_role.new_user.password }
 output "uri" {
-  value = format("postgresql://%s:%s@%s:%d/%s",
+  value = format(
+    "postgresql://%s:%s@%s:%d/%s",
     postgresql_role.new_user.name,
     postgresql_role.new_user.password,
     var.hostname,
     var.port,
-  var.db_name)
+    var.db_name,
+  )
 }
 output "jdbcUrl" {
-  value = format("jdbc:postgresql://%s:%d/%s?user=%s\u0026password=%s\u0026useSSL=%v",
+  value = format(
+    "jdbc:postgresql://%s:%d/%s?user=%s\u0026password=%s\u0026useSSL=%v",
     var.hostname,
     var.port,
     var.db_name,
     postgresql_role.new_user.name,
     postgresql_role.new_user.password,
-  var.use_tls)
+    var.require_ssl,
+  )
 }

--- a/terraform/postgresql/bind/variables.tf
+++ b/terraform/postgresql/bind/variables.tf
@@ -17,5 +17,5 @@ variable "hostname" { type = string }
 variable "port" { type = number }
 variable "admin_username" { type = string }
 variable "admin_password" { type = string }
-variable "use_tls" { type = bool }
+variable "require_ssl" { type = bool }
 variable "provider_verify_certificate" { type = bool }

--- a/terraform/postgresql/provision/data.tf
+++ b/terraform/postgresql/provision/data.tf
@@ -38,8 +38,6 @@ locals {
 
   subnet_group = length(var.rds_subnet_group) > 0 ? var.rds_subnet_group : aws_db_subnet_group.rds-private-subnet[0].name
 
-  parameter_group_name = length(var.parameter_group_name) == 0 ? format("default.%s%s", var.engine, var.engine_version) : var.parameter_group_name
-
   max_allocated_storage = (var.storage_autoscale && var.storage_autoscale_limit_gb > var.storage_gb) ? var.storage_autoscale_limit_gb : null
 
   rds_vpc_security_group_ids = length(var.rds_vpc_security_group_ids) == 0 ? [aws_security_group.rds-sg[0].id] : split(",", var.rds_vpc_security_group_ids)

--- a/terraform/postgresql/provision/main.tf
+++ b/terraform/postgresql/provision/main.tf
@@ -58,7 +58,7 @@ resource "aws_db_instance" "db_instance" {
   db_name                     = var.db_name
   username                    = random_string.username.result
   password                    = random_password.password.result
-  parameter_group_name        = local.parameter_group_name
+  parameter_group_name        = length(var.parameter_group_name) == 0 ? aws_db_parameter_group.db_parameter_group[0].name : var.parameter_group_name
   tags                        = var.labels
   vpc_security_group_ids      = local.rds_vpc_security_group_ids
   db_subnet_group_name        = local.subnet_group
@@ -73,5 +73,16 @@ resource "aws_db_instance" "db_instance" {
 
   lifecycle {
     prevent_destroy = true
+  }
+}
+
+resource "aws_db_parameter_group" "db_parameter_group" {
+  count = length(var.parameter_group_name) == 0 ? 1 : 0
+
+  family = format("%s%s", var.engine, var.engine_version)
+
+  parameter {
+    name  = "rds.force_ssl"
+    value = var.require_ssl ? 1 : 0
   }
 }

--- a/terraform/postgresql/provision/outputs.tf
+++ b/terraform/postgresql/provision/outputs.tf
@@ -17,12 +17,16 @@ output "hostname" { value = aws_db_instance.db_instance.address }
 output "port" { value = local.ports[var.engine] }
 output "username" { value = aws_db_instance.db_instance.username }
 output "password" { value = aws_db_instance.db_instance.password }
-output "use_tls" { value = var.use_tls }
+output "require_ssl" { value = var.require_ssl }
 output "provider_verify_certificate" { value = var.provider_verify_certificate }
-output "status" { value = format("created db %s (id: %s) on server %s URL: https://%s.console.aws.amazon.com/rds/home?region=%s#database:id=%s;is-cluster=false",
-  aws_db_instance.db_instance.name,
-  aws_db_instance.db_instance.id,
-  aws_db_instance.db_instance.address,
-  var.region,
-  var.region,
-aws_db_instance.db_instance.id) }
+output "status" {
+  value = format(
+    "created db %s (id: %s) on server %s URL: https://%s.console.aws.amazon.com/rds/home?region=%s#database:id=%s;is-cluster=false",
+    aws_db_instance.db_instance.name,
+    aws_db_instance.db_instance.id,
+    aws_db_instance.db_instance.address,
+    var.region,
+    var.region,
+    aws_db_instance.db_instance.id,
+  )
+}

--- a/terraform/postgresql/provision/variables.tf
+++ b/terraform/postgresql/provision/variables.tf
@@ -33,5 +33,5 @@ variable "rds_vpc_security_group_ids" { type = string }
 variable "allow_major_version_upgrade" { type = bool }
 variable "auto_minor_version_upgrade" { type = bool }
 variable "maintenance_window" { type = string }
-variable "use_tls" { type = bool }
+variable "require_ssl" { type = bool }
 variable "provider_verify_certificate" { type = bool }


### PR DESCRIPTION
The "use_tls" parameter has been renamed to "require_ssl" and when true
(default) it will configure the server to require an SSL connection. It
can be set to false, in which case the server will accept SSL or
non-SSL connections. If "parameter_group_name" is specified then it will
not take effect.

[#182758757](https://www.pivotaltracker.com/story/show/182758757)

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

