### PR TITLE
feat: amend default value to align with AWS reccomended

### DIFF
--- a/acceptance-tests/helpers/brokers/env.go
+++ b/acceptance-tests/helpers/brokers/env.go
@@ -38,6 +38,7 @@ func (b Broker) env() []apps.EnvVar {
 		apps.EnvVar{Name: "ENCRYPTION_ENABLED", Value: true},
 		apps.EnvVar{Name: "ENCRYPTION_PASSWORDS", Value: b.secrets},
 		apps.EnvVar{Name: "BROKERPAK_UPDATES_ENABLED", Value: true},
+		apps.EnvVar{Name: "GSB_COMPATIBILITY_ENABLE_BETA_SERVICES", Value: true},
 		apps.EnvVar{Name: "GSB_PROVISION_DEFAULTS", Value: fmt.Sprintf(`{"aws_vpc_id": %q}`, os.Getenv("AWS_PAS_VPC_ID"))},
 	)
 

--- a/acceptance-tests/upgrade/update_and_upgrade_s3_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_s3_test.go
@@ -51,7 +51,7 @@ var _ = Describe("UpgradeS3Test", Label("upgrade"), func() {
 			serviceBroker.UpdateSourceDir(developmentBuildDir)
 
 			By("re-applying the terraform for service instance")
-			serviceInstance.Update("-p", "public-read")
+			serviceInstance.Update("-c", `{"boc_object_ownership":"ObjectWriter"}`)
 
 			By("checking that previously written data is accessible")
 			got = appTwo.GET(blobNameOne)

--- a/aws-s3-bucket.yml
+++ b/aws-s3-bucket.yml
@@ -78,7 +78,7 @@ provision:
         BucketOwnerPreferred: BucketOwnerPreferred
         ObjectWriter: ObjectWriter
         BucketOwnerEnforced: BucketOwnerEnforced
-      default: ObjectWriter
+      default: BucketOwnerEnforced
     - field_name: aws_access_key_id
       type: string
       details: AWS access key

--- a/integration-tests/s3_test.go
+++ b/integration-tests/s3_test.go
@@ -84,7 +84,7 @@ var _ = Describe("S3", Label("s3"), func() {
 					HaveKeyWithValue("region", "us-west-2"),
 					HaveKeyWithValue("acl", "private"),
 					HaveKeyWithValue("ol_enabled", false),
-					HaveKeyWithValue("boc_object_ownership", "ObjectWriter"),
+					HaveKeyWithValue("boc_object_ownership", "BucketOwnerEnforced"),
 					HaveKeyWithValue("pab_block_public_acls", false),
 					HaveKeyWithValue("pab_block_public_policy", false),
 					HaveKeyWithValue("pab_ignore_public_acls", false),


### PR DESCRIPTION
AWS suggest using BucketOwnerEnforced for ownership controls,
we had to amend the value updated in the tests as ACLs are
disabled through the use of this value.

[#182479512](https://www.pivotaltracker.com/story/show/182479512)

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

