### PR TITLE
feat: allow s3 encryption value to set to null

### DIFF
--- a/aws-s3-bucket.yml
+++ b/aws-s3-bucket.yml
@@ -91,12 +91,14 @@ provision:
       default: false
     - field_name: sse_default_kms_master_key_id
       type: string
+      nullable: true
       details: The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of `sse_default_algorithm` as `aws:kms`.
-      default: ""
+      default: null
     - field_name: sse_default_algorithm
       type: string
+      nullable: true
       details: The server-side encryption algorithm to use. Valid values are `AES256` and `aws:kms`. (see https://docs.aws.amazon.com/AmazonS3/latest/userguide/serv-side-encryption.html)
-      default: ""
+      default: null
     - field_name: sse_bucket_key_enabled
       type: boolean
       details: Whether or not to use Amazon S3 Bucket Keys for SSE-KMS. (see https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html).

--- a/integration-tests/s3_test.go
+++ b/integration-tests/s3_test.go
@@ -91,8 +91,8 @@ var _ = Describe("S3", Label("s3"), func() {
 					HaveKeyWithValue("pab_block_public_policy", false),
 					HaveKeyWithValue("pab_ignore_public_acls", false),
 					HaveKeyWithValue("pab_restrict_public_buckets", false),
-					HaveKeyWithValue("sse_default_kms_master_key_id", ""),
-					HaveKeyWithValue("sse_default_algorithm", ""),
+					HaveKeyWithValue("sse_default_kms_master_key_id", BeNil()),
+					HaveKeyWithValue("sse_default_algorithm", BeNil()),
 					HaveKeyWithValue("sse_bucket_key_enabled", false),
 					HaveKeyWithValue("aws_access_key_id", awsAccessKeyID),
 					HaveKeyWithValue("aws_secret_access_key", awsSecretAccessKey),
@@ -183,7 +183,7 @@ var _ = Describe("S3", Label("s3"), func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		DescribeTable("should allow updating properties not flagged as `prohibit_update` and not specified in the plan",
+		DescribeTable("should allow updating properties",
 			func(params map[string]any) {
 				err := broker.Update(instanceID, s3ServiceName, customS3Plan["name"].(string), params)
 
@@ -198,7 +198,9 @@ var _ = Describe("S3", Label("s3"), func() {
 			Entry("update pab_ignore_public_acls", map[string]any{"pab_ignore_public_acls": true}),
 			Entry("update pab_restrict_public_buckets", map[string]any{"pab_restrict_public_buckets": true}),
 			Entry("update sse apply_server_side_encryption_by_default block", map[string]any{"sse_default_kms_master_key_id": "key-arn", "sse_default_algorithm": "aws:kms", "sse_bucket_key_enabled": true}),
-			Entry("update sse_default_algorithm", map[string]any{"sse_default_algorithm": "AES256"}),
+			Entry("update sse_default_kms_master_key_id null", map[string]any{"sse_default_kms_master_key_id": nil}),
+			Entry("update sse_default_algorithm string", map[string]any{"sse_default_algorithm": "AES256"}),
+			Entry("update sse_default_algorithm null", map[string]any{"sse_default_algorithm": nil}),
 			Entry("update sse_bucket_key_enabled", map[string]any{"sse_bucket_key_enabled": true}),
 			Entry("update ol_configuration_default_retention_enabled", map[string]any{"ol_configuration_default_retention_enabled": false}),
 			Entry("update ol_configuration_default_retention_mode", map[string]any{"ol_configuration_default_retention_mode": "COMPLIANCE"}),

--- a/terraform/s3/provision/main.tf
+++ b/terraform/s3/provision/main.tf
@@ -53,12 +53,12 @@ resource "aws_s3_bucket_public_access_block" "bucket_public_access_block" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "server_side_encryption_configuration" {
-  count  = (var.sse_default_algorithm != "" || var.sse_bucket_key_enabled != false) ? 1 : 0
+  count  = (var.sse_default_algorithm != null || var.sse_bucket_key_enabled != false) ? 1 : 0
   bucket = aws_s3_bucket.b.bucket
 
   rule {
     dynamic "apply_server_side_encryption_by_default" {
-      for_each = length(var.sse_default_algorithm) > 0 ?  var.sse_default_algorithm[*] : []
+      for_each = var.sse_default_algorithm[*]
       content {
         kms_master_key_id = var.sse_default_kms_master_key_id
         sse_algorithm     = var.sse_default_algorithm


### PR DESCRIPTION
This relates to the properties:
- sse_default_kms_master_key_id
- sse_default_algorithm

These are string values and can be set. When trying to unset them, there
has been some debate as to whether they should be set to "null" or
whether they should be set to the empty string "". Since the
introduction of a new feature allowing strings to be nullable, we have
decided that the best way to unset these properties is to set them to
"null". This change marks the fields as nullable, and mostly reverts PR #388

See: https://github.com/cloudfoundry/cloud-service-broker/pull/584

[#182296596](https://www.pivotaltracker.com/story/show/182296596)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

