### PR TITLE
feat: enable Terraform upgrades

### DIFF
--- a/acceptance-tests/helpers/brokers/create.go
+++ b/acceptance-tests/helpers/brokers/create.go
@@ -6,7 +6,10 @@ import (
 	"csbbrokerpakaws/acceptance-tests/helpers/random"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
+
+	"github.com/onsi/gomega"
 )
 
 type Option func(broker *Broker)
@@ -55,6 +58,7 @@ func WithPrefix(prefix string) Option {
 }
 
 func WithSourceDir(dir string) Option {
+	gomega.Expect(filepath.Join(dir, "cloud-service-broker")).To(gomega.BeAnExistingFile())
 	return func(b *Broker) {
 		b.dir = dir
 	}

--- a/acceptance-tests/helpers/brokers/env.go
+++ b/acceptance-tests/helpers/brokers/env.go
@@ -53,5 +53,6 @@ func (b Broker) latestEnv() []apps.EnvVar {
 	return []apps.EnvVar{
 		{Name: "GSB_COMPATIBILITY_ENABLE_BETA_SERVICES", Value: true},
 		{Name: "GSB_SERVICE_CSB_AWS_S3_BUCKET_PLANS", Value: `[{"name":"default","id":"f64891b4-5021-4742-9871-dfe1a9051302","description":"Default S3 plan","display_name":"default"},{"name":"private","id":"8938b4c0-d67f-4c34-9f68-a66deef99b4e","description":"Private S3 bucket","display_name":"Private","acl":"private","boc_object_ownership":"ObjectWriter"}]`},
+		{Name: "TERRAFORM_UPGRADES_ENABLED", Value: true},
 	}
 }

--- a/acceptance-tests/helpers/brokers/update.go
+++ b/acceptance-tests/helpers/brokers/update.go
@@ -6,14 +6,17 @@ import (
 )
 
 func (b *Broker) UpdateBroker(dir string) {
+	WithEnv(b.latestEnv()...)(b)
+
 	b.app.Push(
 		apps.WithName(b.Name),
 		apps.WithDir(dir),
+		apps.WithStartedState(),
+		apps.WithManifest(newManifest(
+			withName(b.Name),
+			withEnv(b.env()...),
+		)),
 	)
-
-	WithEnv(b.latestEnv()...)(b)
-	b.app.SetEnv(b.env()...)
-	b.app.Restart()
 
 	cf.Run("update-service-broker", b.Name, b.username, b.password, b.app.URL)
 }

--- a/acceptance-tests/upgrade/README.md
+++ b/acceptance-tests/upgrade/README.md
@@ -1,0 +1,18 @@
+## Upgrade tests
+
+These tests perform the following flow:
+- Push version A of this brokerpak (with broker)
+- Create some resources
+- Push version B of this brokerpak (with broker)
+- Check that the resources are still accessible
+- Create some more resources
+
+Two flags may be specified to control the versions used:
+- `-releasedBuildDir` specifies a directory with a built brokerpak at version A
+- `-developmentBuildDir` specifies a directory with a built brokerpak at version B
+
+Note that when running Ginkgo, these flags should go after a `--` to distinguish
+them from Ginkgo flags, for example:
+```
+ginkgo -v -- -releasedBuildDir ... -developmentBuildDir ...
+```

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -19,7 +19,7 @@
 - PostgreSQL: a new "deletion_protection" property allows a server to be protected from accidental deletion.
 - PostgreSQL: passwords are stored using "scram". This is enabled only when not defining a custom parameter_group_name. The PostgreSQL admin password is now 64 bytes.
 - PostgreSQL: Only "instance_classes" are now exposed when provisioning or updating an instance. The previous “cores” abstraction is removed, in favor of using the underlying AWS instance class property.
-
+- Terraform upgrade (from 0.12.30 to 0.12.31) has been added
 
 ### Fix:
 - minimum constraints on MySQL and PostreSQL storage_gb are now enforced

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,10 +8,16 @@ platforms:
   arch: amd64
 # - os: darwin
 #   arch: amd64
+terraform_upgrade_path:
+  - version: 0.12.31
 terraform_binaries:
 - name: terraform
   version: 0.12.30
   source: https://github.com/hashicorp/terraform/archive/v0.12.30.zip  
+- name: terraform
+  version: 0.12.31
+  source: https://github.com/hashicorp/terraform/archive/v0.12.31.zip
+  default: true
 - name: terraform-provider-aws
   version: 4.24.0
   source: https://github.com/terraform-providers/terraform-provider-aws/archive/v4.24.0.zip


### PR DESCRIPTION
This enables a basic Terraform upgrade so that the upgrade tests will
behave correctly and update HCL. In a future change we will update the
upgrade path to take it to a much more recent version.

[#182855842](https://www.pivotaltracker.com/story/show/182855842)

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

