### PR TITLE
fix: Keep Postgres version to 11 for all existing plans

### DIFF
--- a/aws-postgresql.yml
+++ b/aws-postgresql.yml
@@ -30,7 +30,7 @@ plans:
   properties:
     cores: 2
     storage_gb: 5
-    postgres_version: 13.4
+    postgres_version: 11
     subsume: false
 - name: medium
   id: e64d07f9-ceb2-40a6-abd9-391047fa3cf5
@@ -39,7 +39,7 @@ plans:
   properties:
     cores: 4
     storage_gb: 10
-    postgres_version: 13.4
+    postgres_version: 11
     subsume: false
 - name: large
   id: 48baef10-a14c-4ae1-aab5-25f26eba941a
@@ -48,7 +48,7 @@ plans:
   properties:
     cores: 8
     storage_gb: 20
-    postgres_version: 13.4
+    postgres_version: 11
     subsume: false
 - name: subsume
   id: 886cb524-1d4f-11eb-b35f-8ba96a9085d7

--- a/aws-postgresql.yml
+++ b/aws-postgresql.yml
@@ -25,7 +25,7 @@ plan_updateable: true
 plans:
 - name: small
   id: ffc51616-228b-41bd-bed1-d601c18d58f5
-  description: 'Beta - PostgreSQL 13.4, minimum 2 cores, minimum 4GB ram, 5GB storage'
+  description: 'Beta - PostgreSQL 11, minimum 2 cores, minimum 4GB ram, 5GB storage'
   display_name: "small (Beta)"
   properties:
     cores: 2
@@ -34,7 +34,7 @@ plans:
     subsume: false
 - name: medium
   id: e64d07f9-ceb2-40a6-abd9-391047fa3cf5
-  description: 'Beta - PostgreSQL 13.4, minimum 4 cores, minimum 8GB ram, 10GB storage'
+  description: 'Beta - PostgreSQL 11, minimum 4 cores, minimum 8GB ram, 10GB storage'
   display_name: "medium (Beta)"
   properties:
     cores: 4
@@ -43,7 +43,7 @@ plans:
     subsume: false
 - name: large
   id: 48baef10-a14c-4ae1-aab5-25f26eba941a
-  description: 'Beta - PostgreSQL 13.4, minimum 8 cores, minimum 16GB ram, 20GB storage'
+  description: 'Beta - PostgreSQL 11, minimum 8 cores, minimum 16GB ram, 20GB storage'
   display_name: "large (Beta)"
   properties:
     cores: 8

--- a/integration-tests/postgresql_test.go
+++ b/integration-tests/postgresql_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 			Expect(mockTerraform.FirstTerraformInvocationVars()).To(
 				SatisfyAll(
 					HaveKeyWithValue("cores", float64(2)),
-					HaveKeyWithValue("postgres_version", "13.4"),
+					HaveKeyWithValue("engine_version", "11"),
 					HaveKeyWithValue("storage_gb", float64(5)),
 					HaveKeyWithValue("subsume", false),
 					HaveKeyWithValue("require_ssl", true),


### PR DESCRIPTION
Plan version change was not backwards compatible

### Checklist:

* [ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

