### PR TITLE
feat: Deprecate cores and make them not required

### DIFF
--- a/aws-postgresql.yml
+++ b/aws-postgresql.yml
@@ -73,9 +73,8 @@ provision:
                                  "aws_db_instance.db_instance.status"]
   plan_inputs:
   - field_name: cores
-    required: true
     type: integer
-    details: Minimum number of cores for service instance.
+    details: Deprecated - Minimum number of cores for service instance. Suggest setting `instance_class` property instead.
     default: 2
     constraints:
       maximum: 64

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -15,7 +15,7 @@
 - PostgreSQL: a new "provider_verify_certificate" property allows for the PostgreSQL Terraform provider to skip the verification of the server certificate.
 - PostgreSQL: server can reject non-SSL connections by default. Renamed "use_tls" to "require_ssl". Wheh the "require_ssl" property is true, it will make the server require SSL connections. When false (default), the server will accept SSL and non-SSL connections.
 - PostgreSQL: Enhanced Monitoring. Amazon RDS provides metrics in real time for the operating system (OS) of the DB instance. Enhanced Monitoring enables all the system metrics and process information for the RDS DB instances on the console.
-- PostgreSQL: Only "instance_class" are now exposed when provisioning or updating an instance. The previous “cores” abstraction is removed, in favor of using the underlying AWS instance class property.
+- PostgreSQL: Only "instance_class" are now exposed when provisioning or updating an instance. The previous “cores” abstraction is deprecated, in favour of using the underlying AWS instance class property.
 - PostgreSQL: Automated backups can now be scheduled through "backup_window". By default, the automated backups are disabled.
 - PostgreSQL: Automated backups can be customised through the following properties: "delete_automated_backups" - delete backups when deleting the instance, defaults to true; "copy_tags_to_snapshot" - copy all instance tags to snapshots, defaults to true. 
 - PostgreSQL: Added deprecation warning to `cores` property and made it optional. It is recomended to use the `instance_class` property instead. 

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -18,6 +18,7 @@
 - PostgreSQL: Only "instance_class" are now exposed when provisioning or updating an instance. The previous “cores” abstraction is removed, in favor of using the underlying AWS instance class property.
 - PostgreSQL: Automated backups can now be scheduled through "backup_window". By default, the automated backups are disabled.
 - PostgreSQL: Automated backups can be customised through the following properties: "delete_automated_backups" - delete backups when deleting the instance, defaults to true; "copy_tags_to_snapshot" - copy all instance tags to snapshots, defaults to true. 
+- PostgreSQL: Added deprecation warning to `cores` property and made it optional. It is recomended to use the `instance_class` property instead. 
 - Terraform upgrade (from 0.12.30 to 0.12.31) has been added
 
 ### Fix:


### PR DESCRIPTION
Cores are a translation layer to the `instance_class` property. Added recommendation to use instance_class

[#182854680](https://www.pivotaltracker.com/story/show/182854680)

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

