### PR TITLE
test: amend default Postgresql plan to work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ PARALLEL_JOB_COUNT := $(or $(PARALLEL_JOB_COUNT), 10000)
 GSB_PROVISION_DEFAULTS := $(or $(GSB_PROVISION_DEFAULTS), {"aws_vpc_id": "$(AWS_PAS_VPC_ID)"})
 GSB_COMPATIBILITY_ENABLE_BETA_SERVICES := $(or $(GSB_COMPATIBILITY_ENABLE_BETA_SERVICES), true)
 export GSB_SERVICE_CSB_AWS_S3_BUCKET_PLANS = [{"name":"default","id":"f64891b4-5021-4742-9871-dfe1a9051302","description":"Default S3 plan","display_name":"default"}]
-export GSB_SERVICE_CSB_AWS_POSTGRESQL_PLANS = [{"name":"default","id":"de7dbcee-1c8d-11ed-9904-5f435c1e2316","description":"Default Postgres plan","display_name":"default","instance_class": "db.m6i.large","postgres_version": "14.2","storage_gb": 10}]
+export GSB_SERVICE_CSB_AWS_POSTGRESQL_PLANS = [{"name":"default","id":"de7dbcee-1c8d-11ed-9904-5f435c1e2316","description":"Default Postgres plan","display_name":"default","instance_class": "db.m6i.large","postgres_version": "14.2","storage_gb": 100}]
 
 ifeq ($(GO_OK), 0)  # use local go binary
 GO=go

--- a/acceptance-tests/helpers/brokers/env.go
+++ b/acceptance-tests/helpers/brokers/env.go
@@ -53,7 +53,7 @@ func (b Broker) latestEnv() []apps.EnvVar {
 	return []apps.EnvVar{
 		{Name: "GSB_COMPATIBILITY_ENABLE_BETA_SERVICES", Value: true},
 		{Name: "GSB_SERVICE_CSB_AWS_S3_BUCKET_PLANS", Value: `[{"name":"default","id":"f64891b4-5021-4742-9871-dfe1a9051302","description":"Default S3 plan","display_name":"default"},{"name":"private","id":"8938b4c0-d67f-4c34-9f68-a66deef99b4e","description":"Private S3 bucket","display_name":"Private","acl":"private","boc_object_ownership":"ObjectWriter"}]`},
-		{Name: "GSB_SERVICE_CSB_AWS_POSTGRESQL_PLANS", Value: `[{"name":"default","id":"de7dbcee-1c8d-11ed-9904-5f435c1e2316","description":"Default Postgres plan","display_name":"default", "instance_class": "db.m6i.large", "postgres_version": "11", "storage_gb": 10},{"name":"small","id":"ffc51616-228b-41bd-bed1-d601c18d58f5","description":"PostgreSQL 11, minimum 2 cores, minimum 4GB ram, 5GB storage","display_name":"small","storage_gb": 5, "cores": 2, "postgres_version": "11"}]`},
+		{Name: "GSB_SERVICE_CSB_AWS_POSTGRESQL_PLANS", Value: `[{"name":"default","id":"de7dbcee-1c8d-11ed-9904-5f435c1e2316","description":"Default Postgres plan","display_name":"default", "instance_class": "db.m6i.large", "postgres_version": "11", "storage_gb": 100},{"name":"small","id":"ffc51616-228b-41bd-bed1-d601c18d58f5","description":"PostgreSQL 11, minimum 2 cores, minimum 4GB ram, 5GB storage","display_name":"small","storage_gb": 5, "cores": 2, "postgres_version": "11"}]`},
 		{Name: "TERRAFORM_UPGRADES_ENABLED", Value: true},
 	}
 }

--- a/scripts/push-broker.sh
+++ b/scripts/push-broker.sh
@@ -81,7 +81,7 @@ fi
 echo "    GSB_SERVICE_CSB_AWS_S3_BUCKET_PLANS: $(echo "$GSB_SERVICE_CSB_AWS_S3_BUCKET_PLANS" | jq @json)" >>$cfmf
 
 if [[ -z "$GSB_SERVICE_CSB_AWS_POSTGRESQL_PLANS" ]]; then
-  GSB_SERVICE_CSB_AWS_POSTGRESQL_PLANS='[{"name":"default","id":"de7dbcee-1c8d-11ed-9904-5f435c1e2316","description":"Default Postgres plan","display_name":"default","instance_class": "db.m6i.large","postgres_version": "14.2","storage_gb": 10}]'
+  GSB_SERVICE_CSB_AWS_POSTGRESQL_PLANS='[{"name":"default","id":"de7dbcee-1c8d-11ed-9904-5f435c1e2316","description":"Default Postgres plan","display_name":"default","instance_class": "db.m6i.large","postgres_version": "14.2","storage_gb": 100}]'
 fi
 echo "    GSB_SERVICE_CSB_AWS_POSTGRESQL_PLANS: $(echo "$GSB_SERVICE_CSB_AWS_POSTGRESQL_PLANS" | jq @json)" >>$cfmf
 


### PR DESCRIPTION
The default plan needs to have a storage size of 100GB due
to the storage type being `io1`.

[#182758641](https://www.pivotaltracker.com/story/show/182758641)

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

