### PR TITLE
chore: Remove unused computed property engine

### DIFF
--- a/aws-postgresql.yml
+++ b/aws-postgresql.yml
@@ -289,10 +289,6 @@ provision:
     default: ${json.marshal(request.default_labels)}
     overwrite: true
     type: object
-  - name: engine
-    default: postgres
-    overwrite: true
-    type: string
   - name: engine_version
     default: ${postgres_version}
     overwrite: true


### PR DESCRIPTION
In older versions of the MySQL and PostgreSQL services, the same provision file was shared. The engine property was a computed property that is now defined in the data file.

[#183075092](https://www.pivotaltracker.com/story/show/183075092)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

