### PR TITLE
feat: db_name no update

### DIFF
--- a/aws-postgresql.yml
+++ b/aws-postgresql.yml
@@ -126,6 +126,7 @@ provision:
     default: vsbdb
     constraints:
       maxLength: 64
+    prohibit_update: true
   - field_name: publicly_accessible
     type: boolean
     details: Make instance public if true

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -27,6 +27,7 @@
 - PostgreSQL: Performance Insights can now be enabled and a kms key can be provided to encrypt the performance insights data. Performance insights is disabled by default.
 - PostgreSQL: The storage type can now be defined through the property "storage_type". In addition to this, if using the provisioned IOPS SSD (io1) storage type, then the 'iops' value can also be defined through the property "iops".
 - PostgreSQL: There are no default plans defined. Plans must be configured through the environment variable: `GSB_SERVICE_CSB_AWS_POSTGRESQL_PLANS`.
+- PostgreSQL: `db_name` property is no longer updatable. Previously updating this field would have led to data loss as a new database would be created on update.
 - Terraform upgrade (from 0.12.30 to 1.1.9) has been added.
 
 ### Fix:

--- a/integration-tests/postgresql_test.go
+++ b/integration-tests/postgresql_test.go
@@ -220,6 +220,7 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 			},
 			Entry("update region", map[string]any{"region": "no-matter-what-region"}),
 			Entry("update kms_key_id", map[string]any{"kms_key_id": "no-matter-what-key"}),
+			Entry("update db_name", map[string]any{"db_name": "no-matter-what-name"}),
 		)
 
 		DescribeTable(


### PR DESCRIPTION
Updating the db_name property results in a destructive
action as the db is recreated by Terraform.
This change fails the update quickly for improved user
experience.

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

