### PR TITLE
chore: "make run" should target current platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,8 @@ $(IAAS)-services-*.brokerpak: *.yml terraform/*/*/*.tf terraform/*/*/*/*.tf | $(
 
 ###### Run ###################################################################
 .PHONY: run
-run: build aws_access_key_id aws_secret_access_key ## start broker with this brokerpak
+run: aws_access_key_id aws_secret_access_key ## start broker with this brokerpak
+	$(RUN_CSB) pak build --target current
 	$(RUN_CSB) serve
 
 ###### docs ###################################################################


### PR DESCRIPTION
The "make run" command starts a CSB. Previously, when running on a Mac
it was necessary to update the manifest to make sure that Darwin
binaries were added to the brokerpak. But now we can make use of the new
"csb pak build --target" flag to do this automatically.

[#181407433](https://www.pivotaltracker.com/story/show/181407433)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

