### PR TITLE
test: Add test for s3 migration from legacy

### DIFF
--- a/acceptance-tests/apps/s3app/internal/credentials/credentials.go
+++ b/acceptance-tests/apps/s3app/internal/credentials/credentials.go
@@ -16,19 +16,59 @@ type S3Service struct {
 	Arn              string `mapstructure:"arn"`
 }
 
+type S3ServiceLegacy struct {
+	AccessKeyId     string `mapstructure:"access_key_id"`
+	AccessKeySecret string `mapstructure:"secret_access_key"`
+	Region          string `mapstructure:"region"`
+	BucketName      string `mapstructure:"bucket"`
+}
+
 func Read() (S3Service, error) {
+	serviceTag, serviceCred, err := findService()
+	if err != nil {
+		return S3Service{}, err
+	}
+	switch serviceTag {
+	case "s3":
+		return ReadCSBS3(serviceCred)
+	case "aws-s3":
+		return ReadLegacyS3(serviceCred)
+	}
+
+	return S3Service{}, fmt.Errorf("unable to find credentials for S3")
+}
+
+func findService() (string, cfenv.Service, error) {
 	app, err := cfenv.Current()
 	if err != nil {
-		return S3Service{}, fmt.Errorf("error reading app env: %w", err)
-	}
-	svs, err := app.Services.WithTag("s3")
-	if err != nil {
-		return S3Service{}, fmt.Errorf("error reading S3 service details")
+		return "", cfenv.Service{}, fmt.Errorf("error reading app env: %w", err)
 	}
 
+	for _, f := range []func() (string, []cfenv.Service, error){
+		func() (string, []cfenv.Service, error) {
+			serviceTag := "s3"
+			srv, err := app.Services.WithTag(serviceTag)
+			return serviceTag, srv, err
+
+		},
+		func() (string, []cfenv.Service, error) {
+			serviceLabel := "aws-s3"
+			srv, err := app.Services.WithLabel(serviceLabel)
+			return serviceLabel, srv, err
+		},
+	} {
+		serviceType, svs, err := f()
+		if err == nil && len(svs) > 0 {
+			return serviceType, svs[0], nil
+		}
+	}
+
+	return "", cfenv.Service{}, fmt.Errorf("unable to find credentials for S3")
+}
+
+func ReadCSBS3(svs cfenv.Service) (S3Service, error) {
 	var s S3Service
-
-	if err := mapstructure.Decode(svs[0].Credentials, &s); err != nil {
+	if err := mapstructure.Decode(svs.Credentials, &s); err != nil {
 		return S3Service{}, fmt.Errorf("failed to decode credentials: %w", err)
 	}
 
@@ -42,4 +82,25 @@ func Read() (S3Service, error) {
 	}
 
 	return s, nil
+}
+
+func ReadLegacyS3(svs cfenv.Service) (S3Service, error) {
+	var s S3ServiceLegacy
+	if err := mapstructure.Decode(svs.Credentials, &s); err != nil {
+		return S3Service{}, fmt.Errorf("failed to decode credentials: %w", err)
+	}
+
+	if s.AccessKeyId == "" ||
+		s.AccessKeySecret == "" ||
+		s.Region == "" ||
+		s.BucketName == "" {
+		return S3Service{}, fmt.Errorf("parsed credentials are not valid")
+	}
+
+	return S3Service{
+		AccessKeyId:     s.AccessKeyId,
+		AccessKeySecret: s.AccessKeySecret,
+		Region:          s.Region,
+		BucketName:      s.BucketName,
+	}, nil
 }

--- a/acceptance-tests/s3_migration_test.go
+++ b/acceptance-tests/s3_migration_test.go
@@ -1,0 +1,74 @@
+package acceptance_tests_test
+
+import (
+	"csbbrokerpakaws/acceptance-tests/helpers/dms"
+	"fmt"
+	"time"
+
+	"csbbrokerpakaws/acceptance-tests/helpers/apps"
+	"csbbrokerpakaws/acceptance-tests/helpers/random"
+	"csbbrokerpakaws/acceptance-tests/helpers/services"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("S3 Migration", Label("s3-migration"), func() {
+	It("can migrate instance from the previous legacy broker to the CSB", func() {
+		By("creating an S3 bucket using the legacy broker")
+		legacyServiceInstance := services.CreateInstance(
+			"aws-s3",
+			services.WithPlan("standard"),
+			services.WithBrokerName("aws-services-broker"),
+		)
+
+		By("pushing an unstarted app")
+		appOne := apps.Push(apps.WithApp(apps.S3))
+		defer apps.Delete(appOne)
+
+		By("binding the apps to the legacy service instance")
+		legacyBinding := legacyServiceInstance.Bind(appOne)
+
+		By("starting the app")
+		apps.Start(appOne)
+
+		By("uploading files using the first app")
+		filename1 := random.Hexadecimal()
+		fileContent1 := fmt.Sprintf("This is a dummy file that will be uploaded the S3 at %s.", time.Now().String())
+		appOne.PUT(fileContent1, filename1)
+
+		filename2 := random.Hexadecimal()
+		fileContent2 := fmt.Sprintf("This is another dummy file that will be uploaded the S3 at %s.", time.Now().String())
+		appOne.PUT(fileContent2, filename2)
+
+		By("creating an S3 bucket using the CSB broker")
+		targetServiceInstance := services.CreateInstance(
+			"csb-aws-s3-bucket",
+			services.WithPlan("default"),
+			services.WithDefaultBroker(),
+		)
+		defer targetServiceInstance.Delete()
+
+		By("syncing up the legacy S3 to the new S3")
+		sourceBucketLocation := "s3://cf-" + legacyServiceInstance.GUID()
+		targetBucketLocation := "s3://csb-" + targetServiceInstance.GUID()
+		result := dms.AWS("s3", "sync", sourceBucketLocation, targetBucketLocation)
+		Expect(result).To(SatisfyAll(
+			ContainSubstring(fmt.Sprintf("copy: %s/%s to %s/%s", sourceBucketLocation, filename1, targetBucketLocation, filename1)),
+			ContainSubstring(fmt.Sprintf("copy: %s/%s to %s/%s", sourceBucketLocation, filename2, targetBucketLocation, filename2)),
+		))
+
+		By("switching the app data source from the legacy S3 to the new S3")
+		legacyBinding.Unbind()
+		targetServiceInstance.Bind(appOne)
+		apps.Restart(appOne)
+
+		By("checking existing data can be accessed using the new S3 instance")
+		Expect(appOne.GET(filename1)).To(Equal(fileContent1))
+		Expect(appOne.GET(filename2)).To(Equal(fileContent2))
+
+		By("deleting the file from bucket using the second app")
+		appOne.DELETE(filename1)
+		appOne.DELETE(filename2)
+	})
+})


### PR DESCRIPTION
Test validates that the `aws s3 sync` command can be used to migrate S3 instances from the old broker to the new broker.

[#182845406](https://www.pivotaltracker.com/story/show/182845406)

### Checklist:

* [ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

