### PR TITLE
chore: eliminate uses of db_instance.name

### DIFF
--- a/terraform/mysql/provision/outputs.tf
+++ b/terraform/mysql/provision/outputs.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-output "name" { value = aws_db_instance.db_instance.name }
+output "name" { value = aws_db_instance.db_instance.db_name }
 output "hostname" { value = aws_db_instance.db_instance.address }
 output "username" { value = aws_db_instance.db_instance.username }
 output "password" {
@@ -21,7 +21,7 @@ output "password" {
 }
 output "use_tls" { value = var.use_tls }
 output "status" { value = format("created db %s (id: %s) on server %s URL: https://%s.console.aws.amazon.com/rds/home?region=%s#database:id=%s;is-cluster=false",
-  aws_db_instance.db_instance.name,
+  aws_db_instance.db_instance.db_name,
   aws_db_instance.db_instance.id,
   aws_db_instance.db_instance.address,
   var.region,

--- a/terraform/postgresql/provision/outputs.tf
+++ b/terraform/postgresql/provision/outputs.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-output "name" { value = aws_db_instance.db_instance.name }
+output "name" { value = aws_db_instance.db_instance.db_name }
 output "hostname" { value = aws_db_instance.db_instance.address }
 output "username" { value = aws_db_instance.db_instance.username }
 output "password" {
@@ -24,7 +24,7 @@ output "provider_verify_certificate" { value = var.provider_verify_certificate }
 output "status" {
   value = format(
     "created db %s (id: %s) on server %s URL: https://%s.console.aws.amazon.com/rds/home?region=%s#database:id=%s;is-cluster=false",
-    aws_db_instance.db_instance.name,
+    aws_db_instance.db_instance.db_name,
     aws_db_instance.db_instance.id,
     aws_db_instance.db_instance.address,
     var.region,


### PR DESCRIPTION
The db_instance.name property is deprecated.

[#183456412](https://www.pivotaltracker.com/story/show/183456412)

### Checklist:

* ~~[ ] Have you added Release Notes in the docs repositories?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

