### PR TITLE
feat: storage encrypted shouldn't be changed

### DIFF
--- a/aws-mysql.yml
+++ b/aws-mysql.yml
@@ -109,6 +109,7 @@ provision:
     type: boolean
     default: false
     details: Enable encrypted storage
+    prohibit_update: true
   - field_name: parameter_group_name
     type: string
     default: ""

--- a/aws-postgresql.yml
+++ b/aws-postgresql.yml
@@ -74,6 +74,7 @@ provision:
     type: boolean
     default: false
     details: Enable encrypted storage
+    prohibit_update: true
   - field_name: kms_key_id
     type: string
     default: ""

--- a/integration-tests/mysql_test.go
+++ b/integration-tests/mysql_test.go
@@ -263,6 +263,7 @@ var _ = Describe("MySQL", Label("MySQL"), func() {
 			},
 			Entry("update region", map[string]any{"region": "no-matter-what-region"}),
 			Entry("update db_name", map[string]any{"db_name": "no-matter-what-name"}),
+			Entry("update storage_encrypted", map[string]any{"storage_encrypted": true}),
 		)
 
 		DescribeTable("should allow updating properties",
@@ -276,7 +277,6 @@ var _ = Describe("MySQL", Label("MySQL"), func() {
 			Entry("update iops", map[string]any{"iops": 1500}),
 			Entry("update storage_autoscale", map[string]any{"storage_autoscale": true}),
 			Entry("update storage_autoscale_limit_gb", map[string]any{"storage_autoscale_limit_gb": 2}),
-			Entry("update storage_encrypted", map[string]any{"storage_encrypted": true}),
 			Entry("update deletion_protection", map[string]any{"deletion_protection": false}),
 			Entry("update backup_retention_period", map[string]any{"backup_retention_period": float64(2)}),
 			Entry("update backup_window", map[string]any{"backup_window": "01:02-03:04"}),

--- a/integration-tests/postgresql_test.go
+++ b/integration-tests/postgresql_test.go
@@ -228,6 +228,7 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 			Entry("update region", map[string]any{"region": "no-matter-what-region"}),
 			Entry("update kms_key_id", map[string]any{"kms_key_id": "no-matter-what-key"}),
 			Entry("update db_name", map[string]any{"db_name": "no-matter-what-name"}),
+			Entry("update storage_encrypted", map[string]any{"storage_encrypted": true}),
 		)
 
 		DescribeTable(


### PR DESCRIPTION
changing storage encrypted will trigger a recreate. We wan't to avoid recreating service instances as much as possible.

update tests to check for the param being not changeable anymore.

[#179839584]

### Checklist:

* [x] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

