### PR TITLE
feat: Aurora MySQL enable serverless

### DIFF
--- a/aws-aurora-mysql.yml
+++ b/aws-aurora-mysql.yml
@@ -34,6 +34,21 @@ provision:
         - asia-northeast1
       pattern: ^[a-z][a-z0-9-]+$
     prohibit_update: true
+  - field_name: serverless_min_capacity
+    type: number
+    nullable: true
+    details: The minimum capacity for the cluster. Must be less than or equal to `serverless_max_capacity`. Valid capacity values are in a range of 0.5 up to 128 in steps of 0.5.
+    default: null
+  - field_name: serverless_max_capacity
+    type: number
+    nullable: true
+    details: The maximum capacity for the cluster. Must be greater than or equal to `serverless_min_capacity`. Valid capacity values are in a range of 0.5 up to 128 in steps of 0.5.
+    default: null
+  - field_name: engine_version
+    type: string
+    nullable: true
+    details: The Aurora engine version, e.g. "8.0.mysql_aurora.3.02.0". Not all features are supported by all versions. Refer to the AWS documentation for more details.
+    default: null
   - field_name: aws_access_key_id
     type: string
     details: AWS access key

--- a/terraform/aurora-mysql/provision/data.tf
+++ b/terraform/aurora-mysql/provision/data.tf
@@ -11,5 +11,6 @@ data "aws_subnets" "all" {
 }
 
 locals {
-  port = 3306
+  port       = 3306
+  serverless = var.serverless_max_capacity != null || var.serverless_min_capacity != null
 }

--- a/terraform/aurora-mysql/provision/main.tf
+++ b/terraform/aurora-mysql/provision/main.tf
@@ -33,6 +33,7 @@ resource "random_password" "password" {
 resource "aws_rds_cluster" "cluster" {
   cluster_identifier     = var.instance_name
   engine                 = "aurora-mysql"
+  engine_version         = var.engine_version
   database_name          = "auroradb"
   master_username        = random_string.username.result
   master_password        = random_password.password.result
@@ -40,6 +41,14 @@ resource "aws_rds_cluster" "cluster" {
   db_subnet_group_name   = aws_db_subnet_group.rds_private_subnet.name
   vpc_security_group_ids = [aws_security_group.rds_sg.id]
   skip_final_snapshot    = true
+
+  dynamic "serverlessv2_scaling_configuration" {
+    for_each = local.serverless ? [null] : []
+    content {
+      min_capacity = var.serverless_min_capacity
+      max_capacity = var.serverless_max_capacity
+    }
+  }
 
   lifecycle {
     prevent_destroy = true
@@ -50,7 +59,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   count                = var.cluster_instances
   identifier           = "${var.instance_name}-${count.index}"
   cluster_identifier   = aws_rds_cluster.cluster.id
-  instance_class       = "db.r5.large"
+  instance_class       = local.serverless ? "db.serverless" : "db.r5.large"
   engine               = aws_rds_cluster.cluster.engine
   engine_version       = aws_rds_cluster.cluster.engine_version
   db_subnet_group_name = aws_db_subnet_group.rds_private_subnet.name

--- a/terraform/aurora-mysql/provision/variables.tf
+++ b/terraform/aurora-mysql/provision/variables.tf
@@ -4,3 +4,6 @@ variable "region" { type = string }
 variable "instance_name" { type = string }
 variable "aws_vpc_id" { type = string }
 variable "cluster_instances" { type = number }
+variable "serverless_min_capacity" { type = number }
+variable "serverless_max_capacity" { type = number }
+variable "engine_version" { type = string }

--- a/terraform/mysql/provision/main.tf
+++ b/terraform/mysql/provision/main.tf
@@ -41,8 +41,8 @@ resource "random_string" "username" {
 }
 
 resource "random_password" "password" {
-  length           = 32
-  special          = false
+  length  = 32
+  special = false
   // https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.Constraints
   override_special = "~_-."
 }


### PR DESCRIPTION
By setting "serverless_min_capacity" and "serverless_max_capacity" a user can create a cluster in serverless mode (perhaps better called autoscaling mode). It's necessary to set "engine_version" to a version that supports serverless.

[#183390182](https://www.pivotaltracker.com/story/show/183390182)
