### PR TITLE
feat: aurora-pgsql- Add default tags

### DIFF
--- a/aws-aurora-postgresql.yml
+++ b/aws-aurora-postgresql.yml
@@ -84,6 +84,11 @@ provision:
   - field_name: aws_vpc_id
     details: VPC ID for instance
     default: ""
+  computed_inputs:
+  - name: labels
+    default: ${json.marshal(request.default_labels)}
+    overwrite: true
+    type: object
   template_refs:
     outputs: ./terraform/aurora-postgresql/provision/outputs.tf
     provider: ./terraform/aurora-postgresql/provision/provider.tf

--- a/integration-tests/aurora_postgresql_test.go
+++ b/integration-tests/aurora_postgresql_test.go
@@ -98,6 +98,7 @@ var _ = Describe("Aurora PostgreSQL", Label("aurora-postgresql"), func() {
 					HaveKeyWithValue("auto_minor_version_upgrade", BeTrue()),
 					HaveKeyWithValue("rds_vpc_security_group_ids", BeEmpty()),
 					HaveKeyWithValue("rds_subnet_group", BeEmpty()),
+					HaveKeyWithValue("labels", HaveKeyWithValue("pcf-instance-id", instanceID)),
 				))
 		})
 

--- a/terraform-tests/aurora_postgresql_test.go
+++ b/terraform-tests/aurora_postgresql_test.go
@@ -20,6 +20,7 @@ var _ = Describe("Aurora postgresql", Label("aurora-postgresql-terraform"), Orde
 	defaultVars := map[string]any{
 		"instance_name":               "csb-aurorapg-test",
 		"db_name":                     "csbdb",
+		"labels":                      map[string]any{"key1": "some-postgres-value"},
 		"region":                      "us-west-2",
 		"aws_access_key_id":           awsAccessKeyID,
 		"aws_secret_access_key":       awsSecretAccessKey,
@@ -67,6 +68,7 @@ var _ = Describe("Aurora postgresql", Label("aurora-postgresql-terraform"), Orde
 				"instance_class":             Equal("db.r5.large"),
 				"db_subnet_group_name":       Equal("csb-aurorapg-test-p-sn"),
 				"auto_minor_version_upgrade": BeTrue(),
+				"tags":                       HaveKeyWithValue("key1", "some-postgres-value"),
 			}))
 		})
 
@@ -80,6 +82,7 @@ var _ = Describe("Aurora postgresql", Label("aurora-postgresql-terraform"), Orde
 				"skip_final_snapshot":                BeTrue(),
 				"serverlessv2_scaling_configuration": BeEmpty(),
 				"allow_major_version_upgrade":        BeTrue(),
+				"tags":                               HaveKeyWithValue("key1", "some-postgres-value"),
 			}))
 		})
 	})

--- a/terraform/aurora-postgresql/provision/main.tf
+++ b/terraform/aurora-postgresql/provision/main.tf
@@ -38,6 +38,7 @@ resource "aws_rds_cluster" "cluster" {
   engine                      = "aurora-postgresql"
   engine_version              = var.engine_version
   database_name               = var.db_name
+  tags                        = var.labels
   master_username             = random_string.username.result
   master_password             = random_password.password.result
   port                        = local.port
@@ -63,6 +64,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   count                      = var.cluster_instances
   identifier                 = "${var.instance_name}-${count.index}"
   cluster_identifier         = aws_rds_cluster.cluster.id
+  tags                       = var.labels
   instance_class             = local.serverless ? "db.serverless" : "db.r5.large"
   engine                     = aws_rds_cluster.cluster.engine
   engine_version             = aws_rds_cluster.cluster.engine_version

--- a/terraform/aurora-postgresql/provision/variables.tf
+++ b/terraform/aurora-postgresql/provision/variables.tf
@@ -3,6 +3,7 @@ variable "aws_secret_access_key" { type = string }
 variable "region" { type = string }
 variable "instance_name" { type = string }
 variable "db_name" { type = string }
+variable "labels" { type = map(any) }
 variable "aws_vpc_id" { type = string }
 variable "cluster_instances" { type = number }
 variable "serverless_min_capacity" { type = number }


### PR DESCRIPTION
aws_rds_cluster and aws_rds_cluster_instance are tagged with the default pcf tags

[#183567562](https://www.pivotaltracker.com/story/show/183567562)

### Checklist:

* [x] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

