### PR TITLE
feat: aurora-mysql- Add default tags

### DIFF
--- a/aws-aurora-mysql.yml
+++ b/aws-aurora-mysql.yml
@@ -84,6 +84,11 @@ provision:
   - field_name: aws_vpc_id
     details: VPC ID for instance
     default: ""
+  computed_inputs:
+  - name: labels
+    default: ${json.marshal(request.default_labels)}
+    overwrite: true
+    type: object
   template_refs:
     outputs: ./terraform/aurora-mysql/provision/outputs.tf
     provider: ./terraform/aurora-mysql/provision/provider.tf

--- a/integration-tests/aurora_mysql_test.go
+++ b/integration-tests/aurora_mysql_test.go
@@ -97,6 +97,7 @@ var _ = Describe("Aurora MySQL", Label("aurora-mysql"), func() {
 				HaveKeyWithValue("auto_minor_version_upgrade", BeTrue()),
 				HaveKeyWithValue("rds_vpc_security_group_ids", BeEmpty()),
 				HaveKeyWithValue("rds_subnet_group", BeEmpty()),
+				HaveKeyWithValue("labels", HaveKeyWithValue("pcf-instance-id", instanceID)),
 			))
 		})
 

--- a/terraform-tests/aurora_mysql_test.go
+++ b/terraform-tests/aurora_mysql_test.go
@@ -20,6 +20,7 @@ var _ = Describe("Aurora mysql", Label("aurora-mysql-terraform"), Ordered, func(
 	defaultVars := map[string]any{
 		"instance_name":               "csb-auroramysql-test",
 		"db_name":                     "csbdb",
+		"labels":                      map[string]any{"key1": "some-mysql-value"},
 		"region":                      "us-west-2",
 		"aws_access_key_id":           awsAccessKeyID,
 		"aws_secret_access_key":       awsSecretAccessKey,
@@ -67,6 +68,7 @@ var _ = Describe("Aurora mysql", Label("aurora-mysql-terraform"), Ordered, func(
 				"instance_class":             Equal("db.r5.large"),
 				"db_subnet_group_name":       Equal("csb-auroramysql-test-p-sn"),
 				"auto_minor_version_upgrade": BeTrue(),
+				"tags":                       HaveKeyWithValue("key1", "some-mysql-value"),
 			}))
 		})
 
@@ -80,6 +82,7 @@ var _ = Describe("Aurora mysql", Label("aurora-mysql-terraform"), Ordered, func(
 				"skip_final_snapshot":                BeTrue(),
 				"serverlessv2_scaling_configuration": BeEmpty(),
 				"allow_major_version_upgrade":        BeTrue(),
+				"tags":                               HaveKeyWithValue("key1", "some-mysql-value"),
 			}))
 		})
 	})

--- a/terraform/aurora-mysql/provision/main.tf
+++ b/terraform/aurora-mysql/provision/main.tf
@@ -38,6 +38,7 @@ resource "aws_rds_cluster" "cluster" {
   engine                      = "aurora-mysql"
   engine_version              = var.engine_version
   database_name               = var.db_name
+  tags                        = var.labels
   master_username             = random_string.username.result
   master_password             = random_password.password.result
   port                        = local.port
@@ -63,6 +64,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   count                      = var.cluster_instances
   identifier                 = "${var.instance_name}-${count.index}"
   cluster_identifier         = aws_rds_cluster.cluster.id
+  tags                       = var.labels
   instance_class             = local.serverless ? "db.serverless" : "db.r5.large"
   engine                     = aws_rds_cluster.cluster.engine
   engine_version             = aws_rds_cluster.cluster.engine_version

--- a/terraform/aurora-mysql/provision/variables.tf
+++ b/terraform/aurora-mysql/provision/variables.tf
@@ -3,6 +3,7 @@ variable "aws_secret_access_key" { type = string }
 variable "region" { type = string }
 variable "instance_name" { type = string }
 variable "db_name" { type = string }
+variable "labels" { type = map(any) }
 variable "cluster_instances" { type = number }
 variable "aws_vpc_id" { type = string }
 variable "serverless_min_capacity" { type = number }


### PR DESCRIPTION
aws_rds_cluster and aws_rds_cluster_instance are tagged with the default pcf tags

[#183567562](https://www.pivotaltracker.com/story/show/183567562)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

