### PR TITLE
feat: Aurora MySQL TLS connections always enabled

### DIFF
--- a/terraform/aurora-mysql/bind/main.tf
+++ b/terraform/aurora-mysql/bind/main.tf
@@ -12,16 +12,7 @@ resource "random_password" "password" {
   min_special      = 2
 }
 
-resource "mysql_user" "newuser" {
-  user               = random_string.username.result
-  plaintext_password = random_password.password.result
-  host               = "%"
-  tls_option         = "NONE"
-}
-
-resource "mysql_grant" "newuser" {
-  user       = mysql_user.newuser.user
-  database   = var.name
-  host       = mysql_user.newuser.host
-  privileges = ["ALL"]
+resource "csbmysql_binding_user" "new_user" {
+  username = random_string.username.result
+  password = random_password.password.result
 }

--- a/terraform/aurora-mysql/bind/outputs.tf
+++ b/terraform/aurora-mysql/bind/outputs.tf
@@ -1,15 +1,15 @@
 output "hostname" { value = var.reader_endpoint ? var.reader_hostname : var.hostname }
-output "username" { value = random_string.username.result }
+output "username" { value = csbmysql_binding_user.new_user.username }
 output "password" {
-  value     = random_password.password.result
+  value     = csbmysql_binding_user.new_user.password
   sensitive = true
 }
 output "database" { value = var.name }
 output "uri" {
   value = format(
     "mysql://%s:%s@%s:%d/%s",
-    random_string.username.result,
-    random_password.password.result,
+    csbmysql_binding_user.new_user.username,
+    csbmysql_binding_user.new_user.password,
     var.hostname,
     var.port,
     var.name,
@@ -23,8 +23,8 @@ output "jdbcUrl" {
     var.reader_endpoint ? var.reader_hostname : var.hostname,
     var.port,
     var.name,
-    random_string.username.result,
-    random_password.password.result,
+    csbmysql_binding_user.new_user.username,
+    csbmysql_binding_user.new_user.password,
   )
   sensitive = true
 }

--- a/terraform/aurora-mysql/bind/provider.tf
+++ b/terraform/aurora-mysql/bind/provider.tf
@@ -2,5 +2,13 @@ provider "mysql" {
   endpoint = format("%s:%d", var.hostname, var.port)
   username = var.admin_username
   password = var.admin_password
-  tls      = false
+  tls      = true
+}
+
+provider "csbmysql" {
+  database = var.name
+  password = var.admin_password
+  username = var.admin_username
+  port     = var.port
+  host     = var.hostname
 }

--- a/terraform/aurora-mysql/bind/provider.tf
+++ b/terraform/aurora-mysql/bind/provider.tf
@@ -1,10 +1,3 @@
-provider "mysql" {
-  endpoint = format("%s:%d", var.hostname, var.port)
-  username = var.admin_username
-  password = var.admin_password
-  tls      = true
-}
-
 provider "csbmysql" {
   database = var.name
   password = var.admin_password

--- a/terraform/aurora-mysql/bind/versions.tf
+++ b/terraform/aurora-mysql/bind/versions.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/mysql"
       version = ">= 1.9"
     }
+    csbmysql = {
+      source  = "cloud-service-broker/csbmysql"
+      version = ">= 1.0.0"
+    }
     random = {
       source  = "hashicorp/random"
       version = ">= 3.3.2"

--- a/terraform/aurora-mysql/bind/versions.tf
+++ b/terraform/aurora-mysql/bind/versions.tf
@@ -1,9 +1,5 @@
 terraform {
   required_providers {
-    mysql = {
-      source  = "hashicorp/mysql"
-      version = ">= 1.9"
-    }
     csbmysql = {
       source  = "cloud-service-broker/csbmysql"
       version = ">= 1.0.0"


### PR DESCRIPTION
Using the new TF provider, by default, all users will connect using TLS due to the configuration per-account level.

[#183650281](https://www.pivotaltracker.com/story/show/183650281)

### Checklist:

* [x] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

