### PR TITLE
fix: Make rds_vpc_security_group_ids not updatable

### DIFF
--- a/aws-aurora-mysql.yml
+++ b/aws-aurora-mysql.yml
@@ -71,6 +71,7 @@ provision:
     type: string
     details: Comma delimited list of security group ID's for instance
     default: ""
+    prohibit_update: true
   - field_name: auto_minor_version_upgrade
     type: boolean
     details: Allow minor version upgrades automatically during the maintenance window.

--- a/aws-aurora-postgresql.yml
+++ b/aws-aurora-postgresql.yml
@@ -67,6 +67,7 @@ provision:
     type: string
     details: Comma delimited list of security group ID's for instance
     default: ""
+    prohibit_update: true
   - field_name: allow_major_version_upgrade
     type: boolean
     details: Allow major version upgrades. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible.

--- a/aws-mysql.yml
+++ b/aws-mysql.yml
@@ -145,6 +145,7 @@ provision:
     type: string
     details: Comma delimited list of security group ID's for instance
     default: ""    
+    prohibit_update: true
   - field_name: allow_major_version_upgrade
     type: boolean
     details: Allow major version upgrades. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible.

--- a/aws-postgresql.yml
+++ b/aws-postgresql.yml
@@ -146,6 +146,7 @@ provision:
     type: string
     details: Comma delimited list of security group ID's for instance
     default: ""
+    prohibit_update: true
   - field_name: allow_major_version_upgrade
     type: boolean
     details: Allow major version upgrades. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible.

--- a/integration-tests/aurora_mysql_test.go
+++ b/integration-tests/aurora_mysql_test.go
@@ -166,6 +166,7 @@ var _ = Describe("Aurora MySQL", Label("aurora-mysql"), func() {
 			Entry("instance_name", "instance_name", "marmaduke"),
 			Entry("db_name", "db_name", "some-new-name"),
 			Entry("rds_subnet_group", "rds_subnet_group", "some-new-subnet-name"),
+			Entry("rds_vpc_security_group_ids", "rds_vpc_security_group_ids", "group3"),
 		)
 
 		DescribeTable(
@@ -179,7 +180,6 @@ var _ = Describe("Aurora MySQL", Label("aurora-mysql"), func() {
 			Entry("engine_version", "engine_version", "8.0.mysql_aurora.3.02.0"),
 			Entry("allow_major_version_upgrade", "allow_major_version_upgrade", false),
 			Entry("auto_minor_version_upgrade", "auto_minor_version_upgrade", false),
-			Entry("rds_vpc_security_group_ids", "rds_vpc_security_group_ids", "group3"),
 		)
 	})
 })

--- a/integration-tests/aurora_postgresql_test.go
+++ b/integration-tests/aurora_postgresql_test.go
@@ -167,6 +167,7 @@ var _ = Describe("Aurora PostgreSQL", Label("aurora-postgresql"), func() {
 			Entry("instance_name", "instance_name", "marmaduke"),
 			Entry("db_name", "db_name", "someNewName"),
 			Entry("rds_subnet_group", "rds_subnet_group", "some-new-subnet-name"),
+			Entry("rds_vpc_security_group_ids", "rds_vpc_security_group_ids", "group3"),
 		)
 
 		DescribeTable(
@@ -180,7 +181,6 @@ var _ = Describe("Aurora PostgreSQL", Label("aurora-postgresql"), func() {
 			Entry("engine_version", "engine_version", "8.0.postgresql_aurora.3.02.0"),
 			Entry("allow_major_version_upgrade", "allow_major_version_upgrade", false),
 			Entry("auto_minor_version_upgrade", "auto_minor_version_upgrade", false),
-			Entry("rds_vpc_security_group_ids", "rds_vpc_security_group_ids", "group3"),
 			Entry("deletion_protection", "deletion_protection", true),
 		)
 	})

--- a/integration-tests/mysql_test.go
+++ b/integration-tests/mysql_test.go
@@ -21,7 +21,7 @@ var customMySQLPlan = map[string]any{
 	"cores":         4,
 	"storage_gb":    100,
 	"metadata": map[string]any{
-		"displayName": "custom-sample (Beta)",
+		"displayName", "custom-sample (Beta)",
 	},
 }
 
@@ -71,42 +71,42 @@ var _ = Describe("MySQL", Label("MySQL"), func() {
 			},
 			Entry(
 				"invalid region",
-				map[string]any{"region": "-Asia-northeast1"},
+				"region", "-Asia-northeast1},
 				"region: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
 				"instance name minimum length is 6 characters",
-				map[string]any{"instance_name": stringOfLen(5)},
+				"instance_name": stringOfLen(5},
 				"instance_name: String length must be greater than or equal to 6",
 			),
 			Entry(
 				"instance name maximum length is 98 characters",
-				map[string]any{"instance_name": stringOfLen(99)},
+				"instance_name": stringOfLen(99},
 				"instance_name: String length must be less than or equal to 98",
 			),
 			Entry(
 				"instance name invalid characters",
-				map[string]any{"instance_name": ".aaaaa"},
+				"instance_name", ".aaaaa},
 				"instance_name: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
 				"database name maximum length is 64 characters",
-				map[string]any{"db_name": stringOfLen(65)},
+				"db_name": stringOfLen(65},
 				"db_name: String length must be less than or equal to 64",
 			),
 			Entry(
 				"monitoring_interval maximum value is 60",
-				map[string]any{"monitoring_interval": 61},
+				"monitoring_interval": 6},
 				"monitoring_interval: Must be less than or equal to 60",
 			),
 			Entry(
 				"monitoring_interval minimum value is 0",
-				map[string]any{"monitoring_interval": -1},
+				"monitoring_interval": -},
 				"monitoring_interval: Must be greater than or equal to 0",
 			),
 			Entry(
 				"performance_insights_retention_period minimum value is 7",
-				map[string]any{"performance_insights_retention_period": 1},
+				"performance_insights_retention_period": },
 				"performance_insights_retention_period: Must be greater than or equal to 7",
 			),
 		)
@@ -255,7 +255,7 @@ var _ = Describe("MySQL", Label("MySQL"), func() {
 		})
 
 		DescribeTable("should prevent updating properties flagged as `prohibit_update` because it can result in the recreation of the service instance",
-			func(params map[string]any) {
+			func(prop string, value any) {
 				err := broker.Update(instanceID, serviceName, customMySQLPlan["name"].(string), params)
 
 				Expect(err).To(MatchError(
@@ -267,34 +267,34 @@ var _ = Describe("MySQL", Label("MySQL"), func() {
 				const initialProvisionInvocation = 1
 				Expect(mockTerraform.ApplyInvocations()).To(HaveLen(initialProvisionInvocation))
 			},
-			Entry("update region", map[string]any{"region": "no-matter-what-region"}),
-			Entry("update db_name", map[string]any{"db_name": "no-matter-what-name"}),
-			Entry("update kms_key_id", map[string]any{"kms_key_id": "no-matter-what-key"}),
-			Entry("update storage_encrypted", map[string]any{"storage_encrypted": true}),
+			Entry("update region", "region", "no-matter-what-region"),
+			Entry("update db_name", "db_name", "no-matter-what-name"),
+			Entry("update kms_key_id", "kms_key_id", "no-matter-what-key"),
+			Entry("update storage_encrypted", "storage_encrypted", true),
 			Entry("rds_vpc_security_group_ids", "rds_vpc_security_group_ids", "group3"),
 		)
 
 		DescribeTable("should allow updating properties",
-			func(params map[string]any) {
+			func(prop string, value any) {
 				err := broker.Update(instanceID, serviceName, customMySQLPlan["name"].(string), params)
 
 				Expect(err).NotTo(HaveOccurred())
 			},
-			Entry("update storage_type", map[string]any{"storage_type": "gp2"}),
-			Entry("update iops", map[string]any{"iops": 1500}),
-			Entry("update storage_autoscale", map[string]any{"storage_autoscale": true}),
-			Entry("update storage_autoscale_limit_gb", map[string]any{"storage_autoscale_limit_gb": 2}),
-			Entry("update deletion_protection", map[string]any{"deletion_protection": false}),
-			Entry("update backup_retention_period", map[string]any{"backup_retention_period": float64(2)}),
-			Entry("update backup_window", map[string]any{"backup_window": "01:02-03:04"}),
-			Entry("update copy_tags_to_snapshot", map[string]any{"copy_tags_to_snapshot": false}),
-			Entry("update delete_automated_backups", map[string]any{"delete_automated_backups": false}),
-			Entry("update option_group_name", map[string]any{"option_group_name": "option-group-name"}),
-			Entry("update monitoring_interval", map[string]any{"monitoring_interval": 0}),
-			Entry("update monitoring_role_arn", map[string]any{"monitoring_role_arn": ""}),
-			Entry("update performance_insights_enabled", map[string]any{"performance_insights_enabled": true}),
-			Entry("update performance_insights_kms_key_id", map[string]any{"performance_insights_kms_key_id": "arn:aws:kms:us-west-2:649758297924:key/ebbb4ecc-ddfb-4e2f-8e93-c96d7bc43daa"}),
-			Entry("update performance_insights_retention_period", map[string]any{"performance_insights_retention_period": 31}),
+			Entry("update storage_type", "storage_type", "gp2"),
+			Entry("update iops", "iops", 1500),
+			Entry("update storage_autoscale", "storage_autoscale", true),
+			Entry("update storage_autoscale_limit_gb", "storage_autoscale_limit_gb", 2),
+			Entry("update deletion_protection", "deletion_protection", false),
+			Entry("update backup_retention_period", "backup_retention_period", float64(2)),
+			Entry("update backup_window", "backup_window", "01:02-03:04"),
+			Entry("update copy_tags_to_snapshot", "copy_tags_to_snapshot", false),
+			Entry("update delete_automated_backups", "delete_automated_backups", false),
+			Entry("update option_group_name", "option_group_name", "option-group-name"),
+			Entry("update monitoring_interval", "monitoring_interval", 0),
+			Entry("update monitoring_role_arn", "monitoring_role_arn", ""),
+			Entry("update performance_insights_enabled", "performance_insights_enabled": true),
+			Entry("update performance_insights_kms_key_id", "performance_insights_kms_key_id", "arn:aws:kms:us-west-2:649758297924:key/ebbb4ecc-ddfb-4e2f-8e93-c96d7bc43daa"),
+			Entry("update performance_insights_retention_period", "performance_insights_retention_period", 31),
 		)
 	})
 })

--- a/integration-tests/mysql_test.go
+++ b/integration-tests/mysql_test.go
@@ -173,7 +173,7 @@ var _ = Describe("MySQL", Label("MySQL"), func() {
 				"multi_az":                               true,
 				"instance_class":                         "",
 				"rds_subnet_group":                       "",
-				"rds_vpc_security_group_ids":             "",
+				"rds_vpc_security_group_ids":             "group1,group2",
 				"allow_major_version_upgrade":            false,
 				"auto_minor_version_upgrade":             false,
 				"maintenance_day":                        "Mon",
@@ -217,7 +217,7 @@ var _ = Describe("MySQL", Label("MySQL"), func() {
 					HaveKeyWithValue("multi_az", true),
 					HaveKeyWithValue("instance_class", ""),
 					HaveKeyWithValue("rds_subnet_group", ""),
-					HaveKeyWithValue("rds_vpc_security_group_ids", ""),
+					HaveKeyWithValue("rds_vpc_security_group_ids", "group1,group2"),
 					HaveKeyWithValue("allow_major_version_upgrade", false),
 					HaveKeyWithValue("auto_minor_version_upgrade", false),
 					HaveKeyWithValue("maintenance_day", "Mon"),
@@ -271,6 +271,7 @@ var _ = Describe("MySQL", Label("MySQL"), func() {
 			Entry("update db_name", map[string]any{"db_name": "no-matter-what-name"}),
 			Entry("update kms_key_id", map[string]any{"kms_key_id": "no-matter-what-key"}),
 			Entry("update storage_encrypted", map[string]any{"storage_encrypted": true}),
+			Entry("rds_vpc_security_group_ids", "rds_vpc_security_group_ids", "group3"),
 		)
 
 		DescribeTable("should allow updating properties",

--- a/integration-tests/mysql_test.go
+++ b/integration-tests/mysql_test.go
@@ -292,7 +292,7 @@ var _ = Describe("MySQL", Label("MySQL"), func() {
 			Entry("update option_group_name", "option_group_name", "option-group-name"),
 			Entry("update monitoring_interval", "monitoring_interval", 0),
 			Entry("update monitoring_role_arn", "monitoring_role_arn", ""),
-			Entry("update performance_insights_enabled", "performance_insights_enabled": true),
+			Entry("update performance_insights_enabled", "performance_insights_enabled", true),
 			Entry("update performance_insights_kms_key_id", "performance_insights_kms_key_id", "arn:aws:kms:us-west-2:649758297924:key/ebbb4ecc-ddfb-4e2f-8e93-c96d7bc43daa"),
 			Entry("update performance_insights_retention_period", "performance_insights_retention_period", 31),
 		)

--- a/integration-tests/mysql_test.go
+++ b/integration-tests/mysql_test.go
@@ -256,7 +256,7 @@ var _ = Describe("MySQL", Label("MySQL"), func() {
 
 		DescribeTable("should prevent updating properties flagged as `prohibit_update` because it can result in the recreation of the service instance",
 			func(prop string, value any) {
-				err := broker.Update(instanceID, serviceName, customMySQLPlan["name"].(string), params)
+				err := broker.Update(instanceID, serviceName, customMySQLPlan["name"].(string), map[string]any{prop: value})
 
 				Expect(err).To(MatchError(
 					ContainSubstring(
@@ -276,7 +276,7 @@ var _ = Describe("MySQL", Label("MySQL"), func() {
 
 		DescribeTable("should allow updating properties",
 			func(prop string, value any) {
-				err := broker.Update(instanceID, serviceName, customMySQLPlan["name"].(string), params)
+				err := broker.Update(instanceID, serviceName, customMySQLPlan["name"].(string), map[string]any{prop: value})
 
 				Expect(err).NotTo(HaveOccurred())
 			},

--- a/integration-tests/mysql_test.go
+++ b/integration-tests/mysql_test.go
@@ -21,7 +21,7 @@ var customMySQLPlan = map[string]any{
 	"cores":         4,
 	"storage_gb":    100,
 	"metadata": map[string]any{
-		"displayName", "custom-sample (Beta)",
+		"displayName": "custom-sample (Beta)",
 	},
 }
 
@@ -71,42 +71,42 @@ var _ = Describe("MySQL", Label("MySQL"), func() {
 			},
 			Entry(
 				"invalid region",
-				"region", "-Asia-northeast1},
+				map[string]any{"region": "-Asia-northeast1"},
 				"region: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
 				"instance name minimum length is 6 characters",
-				"instance_name": stringOfLen(5},
+				map[string]any{"instance_name": stringOfLen(5)},
 				"instance_name: String length must be greater than or equal to 6",
 			),
 			Entry(
 				"instance name maximum length is 98 characters",
-				"instance_name": stringOfLen(99},
+				map[string]any{"instance_name": stringOfLen(99)},
 				"instance_name: String length must be less than or equal to 98",
 			),
 			Entry(
 				"instance name invalid characters",
-				"instance_name", ".aaaaa},
+				map[string]any{"instance_name": ".aaaaa"},
 				"instance_name: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
 				"database name maximum length is 64 characters",
-				"db_name": stringOfLen(65},
+				map[string]any{"db_name": stringOfLen(65)},
 				"db_name: String length must be less than or equal to 64",
 			),
 			Entry(
 				"monitoring_interval maximum value is 60",
-				"monitoring_interval": 6},
+				map[string]any{"monitoring_interval": 61},
 				"monitoring_interval: Must be less than or equal to 60",
 			),
 			Entry(
 				"monitoring_interval minimum value is 0",
-				"monitoring_interval": -},
+				map[string]any{"monitoring_interval": -1},
 				"monitoring_interval: Must be greater than or equal to 0",
 			),
 			Entry(
 				"performance_insights_retention_period minimum value is 7",
-				"performance_insights_retention_period": },
+				map[string]any{"performance_insights_retention_period": 1},
 				"performance_insights_retention_period: Must be greater than or equal to 7",
 			),
 		)

--- a/integration-tests/postgresql_test.go
+++ b/integration-tests/postgresql_test.go
@@ -109,6 +109,7 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 					HaveKeyWithValue("storage_encrypted", false),
 					HaveKeyWithValue("kms_key_id", ""),
 					HaveKeyWithValue("multi_az", false),
+					HaveKeyWithValue("rds_vpc_security_group_ids", ""),
 					HaveKeyWithValue("allow_major_version_upgrade", true),
 					HaveKeyWithValue("auto_minor_version_upgrade", true),
 					HaveKeyWithValue("maintenance_day", BeNil()),
@@ -145,6 +146,7 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 				"storage_encrypted":                     true,
 				"kms_key_id":                            "arn:aws:xxxx",
 				"multi_az":                              true,
+				"rds_vpc_security_group_ids":            "group1,group2",
 				"allow_major_version_upgrade":           false,
 				"auto_minor_version_upgrade":            false,
 				"maintenance_day":                       "Mon",
@@ -180,6 +182,7 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 					HaveKeyWithValue("storage_encrypted", true),
 					HaveKeyWithValue("kms_key_id", "arn:aws:xxxx"),
 					HaveKeyWithValue("multi_az", true),
+					HaveKeyWithValue("rds_vpc_security_group_ids", "group1,group2"),
 					HaveKeyWithValue("allow_major_version_upgrade", false),
 					HaveKeyWithValue("auto_minor_version_upgrade", false),
 					HaveKeyWithValue("maintenance_day", "Mon"),
@@ -229,6 +232,7 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 			Entry("update kms_key_id", map[string]any{"kms_key_id": "no-matter-what-key"}),
 			Entry("update db_name", map[string]any{"db_name": "no-matter-what-name"}),
 			Entry("update storage_encrypted", map[string]any{"storage_encrypted": true}),
+			Entry("rds_vpc_security_group_ids", "rds_vpc_security_group_ids", "group3"),
 		)
 
 		DescribeTable(

--- a/integration-tests/postgresql_test.go
+++ b/integration-tests/postgresql_test.go
@@ -62,27 +62,27 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 			},
 			Entry(
 				"invalid region",
-				"region": "-Asia-northeast1},
+				map[string]any{"region": "-Asia-northeast1"},
 				"region: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
 				"instance name minimum length is 6 characters",
-				"instance_name": stringOfLen(5},
+				map[string]any{"instance_name": stringOfLen(5)},
 				"instance_name: String length must be greater than or equal to 6",
 			),
 			Entry(
 				"instance name invalid characters",
-				"instance_name": ".aaaaa},
+				map[string]any{"instance_name": ".aaaaa"},
 				"instance_name: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
 				"database name maximum length is 98 characters",
-				"db_name": stringOfLen(99},
+				map[string]any{"db_name": stringOfLen(99)},
 				"db_name: String length must be less than or equal to 64",
 			),
 			Entry(
 				"performance_insights_retention_period minimum value is 7",
-				"performance_insights_retention_period": },
+				map[string]any{"performance_insights_retention_period": 1},
 				"performance_insights_retention_period: Must be greater than or equal to 7",
 			),
 		)

--- a/integration-tests/postgresql_test.go
+++ b/integration-tests/postgresql_test.go
@@ -62,27 +62,27 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 			},
 			Entry(
 				"invalid region",
-				map[string]any{"region": "-Asia-northeast1"},
+				"region": "-Asia-northeast1},
 				"region: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
 				"instance name minimum length is 6 characters",
-				map[string]any{"instance_name": stringOfLen(5)},
+				"instance_name": stringOfLen(5},
 				"instance_name: String length must be greater than or equal to 6",
 			),
 			Entry(
 				"instance name invalid characters",
-				map[string]any{"instance_name": ".aaaaa"},
+				"instance_name": ".aaaaa},
 				"instance_name: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
 				"database name maximum length is 98 characters",
-				map[string]any{"db_name": stringOfLen(99)},
+				"db_name": stringOfLen(99},
 				"db_name: String length must be less than or equal to 64",
 			),
 			Entry(
 				"performance_insights_retention_period minimum value is 7",
-				map[string]any{"performance_insights_retention_period": 1},
+				"performance_insights_retention_period": },
 				"performance_insights_retention_period: Must be greater than or equal to 7",
 			),
 		)
@@ -216,8 +216,8 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 		})
 
 		DescribeTable("should prevent updating properties flagged as `prohibit_update` because it can result in the recreation of the service instance",
-			func(params map[string]any) {
-				err := broker.Update(instanceID, serviceName, "custom-sample", params)
+			func(prop string, value any) {
+			err := broker.Update(instanceID, serviceName, "custom-sample", params)
 
 				Expect(err).To(MatchError(
 					ContainSubstring(
@@ -228,16 +228,16 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 				const initialProvisionInvocation = 1
 				Expect(mockTerraform.ApplyInvocations()).To(HaveLen(initialProvisionInvocation))
 			},
-			Entry("update region", map[string]any{"region": "no-matter-what-region"}),
-			Entry("update kms_key_id", map[string]any{"kms_key_id": "no-matter-what-key"}),
-			Entry("update db_name", map[string]any{"db_name": "no-matter-what-name"}),
-			Entry("update storage_encrypted", map[string]any{"storage_encrypted": true}),
+			Entry("update region", "region", "no-matter-what-region"),
+			Entry("update kms_key_id", "kms_key_id", "no-matter-what-key"),
+			Entry("update db_name", "db_name", "no-matter-what-name"),
+			Entry("update storage_encrypted", "storage_encrypted", true),
 			Entry("rds_vpc_security_group_ids", "rds_vpc_security_group_ids", "group3"),
 		)
 
 		DescribeTable(
 			"some allowed updates",
-			func(key string, value any) {
+			func(prop string, value any) {
 				err := broker.Update(instanceID, serviceName, "custom-sample", map[string]any{key: value})
 
 				Expect(err).NotTo(HaveOccurred())

--- a/integration-tests/postgresql_test.go
+++ b/integration-tests/postgresql_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 
 		DescribeTable("should prevent updating properties flagged as `prohibit_update` because it can result in the recreation of the service instance",
 			func(prop string, value any) {
-			err := broker.Update(instanceID, serviceName, "custom-sample", params)
+				err := broker.Update(instanceID, serviceName, "custom-sample", map[string]any{prop: value})
 
 				Expect(err).To(MatchError(
 					ContainSubstring(
@@ -238,7 +238,7 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 		DescribeTable(
 			"some allowed updates",
 			func(prop string, value any) {
-				err := broker.Update(instanceID, serviceName, "custom-sample", map[string]any{key: value})
+				err := broker.Update(instanceID, serviceName, "custom-sample", map[string]any{prop: value})
 
 				Expect(err).NotTo(HaveOccurred())
 			},


### PR DESCRIPTION
When updated it triggers a DependencyViolation error.

[#183701503](https://www.pivotaltracker.com/story/show/183701503)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

