### PR TITLE
chore: enable local development experience

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,7 @@
+export PAK_BUILD_CACHE_PATH=/tmp/.pak-cache
+export GSB_COMPATIBILITY_ENABLE_BETA_SERVICES=true
+export GSB_SERVICE_CSB_AWS_S3_BUCKET_PLANS='[{"name":"default","id":"f64891b4-5021-4742-9871-dfe1a9051302","description":"Default S3 plan","display_name":"default"}]'
+export GSB_SERVICE_CSB_AWS_POSTGRESQL_PLANS='[{"name":"default","id":"de7dbcee-1c8d-11ed-9904-5f435c1e2316","description":"Default Postgres plan","display_name":"default","instance_class": "db.m6i.large","postgres_version": "14.2","storage_gb": 100}]'
+export GSB_SERVICE_CSB_AWS_AURORA_POSTGRESQL_PLANS='[{"name":"default","id":"d20c5cf2-29e1-11ed-93da-1f3a67a06903","description":"Default Aurora Postgres plan","display_name":"default"}]'
+export GSB_SERVICE_CSB_AWS_AURORA_MYSQL_PLANS='[{"name":"default","id":"10b2bd92-2a0b-11ed-b70f-c7c5cf3bb719","description":"Default Aurora MySQL plan","display_name":"default"}]'
+export GSB_SERVICE_CSB_AWS_MYSQL_PLANS='[{"name":"default","id":"0f3522b2-f040-443b-bc53-4aed25284840","description":"Default MySQL plan","display_name":"default","instance_class": "db.m6i.large","mysql_version": "8.0","storage_gb": 100}]'

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 aws-services-*.brokerpak
 cloud-service-broker
 .aws-terraform-tests
+.csb.db
 

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,6 @@ clean: ## delete build files
 	- rm -f $(IAAS)-services-*.brokerpak
 	- rm -f ./cloud-service-broker
 	- rm -f ./brokerpak-user-docs.md
-	- rm -rf $(PAK_CACHE)
 
 $(PAK_CACHE):
 	@echo "Folder $(PAK_CACHE) does not exist. Creating it..."


### PR DESCRIPTION
Enables the local developement experience from https://github.com/cloudfoundry/cloud-service-broker/pull/660

- Adds the CSB "database" to .gitignore so that it does not get committed
- Stops a "make clean" from emptying the cache, which is no longer needed as the cache works correctly now
- Add enviornment variable mirrors so that the "csb" command can read them, via "direnv" tool
