### PR TITLE
fix: Redis- Removed limitation of redis version

### DIFF
--- a/aws-redis-cluster.yml
+++ b/aws-redis-cluster.yml
@@ -83,11 +83,6 @@ provision:
     required: true
     type: string
     details: The version for the redis instance.
-    enum:
-      3.2: Redis 3.2
-      4.0: Redis 4.0
-      5.0: Redis 5.0
-      6.0: Redis 6.x
   user_inputs:
   - field_name: instance_name
     type: string

--- a/terraform-tests/redis_test.go
+++ b/terraform-tests/redis_test.go
@@ -1,0 +1,74 @@
+package terraformtests
+
+import (
+	"path"
+
+	. "csbbrokerpakaws/terraform-tests/helpers"
+
+	tfjson "github.com/hashicorp/terraform-json"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+var _ = Describe("Redis", Label("redis-terraform"), Ordered, func() {
+	var (
+		plan                  tfjson.Plan
+		terraformProvisionDir string
+	)
+
+	defaultVars := map[string]any{
+		"cache_size":                         2,
+		"redis_version":                      "6.0",
+		"instance_name":                      "csb-redis-test",
+		"labels":                             map[string]any{"key1": "some-redis-value"},
+		"node_type":                          "",
+		"node_count":                         1,
+		"elasticache_subnet_group":           "",
+		"elasticache_vpc_security_group_ids": "",
+		"region":                             "us-west-2",
+		"aws_access_key_id":                  awsAccessKeyID,
+		"aws_secret_access_key":              awsSecretAccessKey,
+		"aws_vpc_id":                         awsVPCID,
+	}
+
+	BeforeAll(func() {
+		terraformProvisionDir = path.Join(workingDir, "redis/cluster/provision")
+		Init(terraformProvisionDir)
+	})
+
+	Context("with Default values", func() {
+		BeforeAll(func() {
+			plan = ShowPlan(terraformProvisionDir, buildVars(defaultVars, map[string]any{}))
+		})
+
+		It("should create the right resources", func() {
+			Expect(plan.ResourceChanges).To(HaveLen(5))
+
+			Expect(ResourceChangesTypes(plan)).To(ConsistOf(
+				"aws_elasticache_replication_group",
+				"random_password",
+				"aws_security_group",
+				"aws_elasticache_subnet_group",
+				"aws_security_group_rule",
+			))
+		})
+
+		It("should create a aws_elasticache_replication_group with the right values", func() {
+			Expect(AfterValuesForType(plan, "aws_elasticache_replication_group")).To(
+				MatchKeys(IgnoreExtras, Keys{
+					"replication_group_id":       Equal("csb-redis-test"),
+					"description":                Equal("csb-redis-test redis"),
+					"node_type":                  Equal("cache.t3.medium"),
+					"num_cache_clusters":         BeNumerically("==", 1),
+					"engine":                     Equal("redis"),
+					"engine_version":             Equal("6.0"),
+					"port":                       BeNumerically("==", 6379),
+					"tags":                       HaveKeyWithValue("key1", "some-redis-value"),
+					"subnet_group_name":          Equal("csb-redis-test-p-sn"),
+					"transit_encryption_enabled": BeTrue(),
+					"automatic_failover_enabled": BeFalse(),
+				}))
+		})
+	})
+})

--- a/terraform/redis/cluster/provision/data.tf
+++ b/terraform/redis/cluster/provision/data.tf
@@ -31,13 +31,6 @@ locals {
     256 = "cache.r5.12xlarge"
   }
 
-  parameter_group_names = {
-    "3.2" = "default.redis3.2"
-    "4.0" = "default.redis4.0"
-    "5.0" = "default.redis5.0"
-    "6.0" = "default.redis6.x"
-  }
-
   node_type = length(var.node_type) == 0 ? local.instance_types[var.cache_size] : var.node_type
   port      = 6379
 

--- a/terraform/redis/cluster/provision/main.tf
+++ b/terraform/redis/cluster/provision/main.tf
@@ -49,7 +49,7 @@ resource "aws_elasticache_replication_group" "redis" {
   description                = format("%s redis", var.instance_name)
   node_type                  = local.node_type
   num_cache_clusters         = var.node_count
-  engine_version       = var.redis_version
+  engine_version             = var.redis_version
   port                       = local.port
   tags                       = var.labels
   security_group_ids         = local.elasticache_vpc_security_group_ids

--- a/terraform/redis/cluster/provision/main.tf
+++ b/terraform/redis/cluster/provision/main.tf
@@ -49,7 +49,7 @@ resource "aws_elasticache_replication_group" "redis" {
   description                = format("%s redis", var.instance_name)
   node_type                  = local.node_type
   num_cache_clusters         = var.node_count
-  parameter_group_name       = local.parameter_group_names[var.redis_version]
+  engine_version       = var.redis_version
   port                       = local.port
   tags                       = var.labels
   security_group_ids         = local.elasticache_vpc_security_group_ids


### PR DESCRIPTION
The version was not being used to set the engine and it was relying on the default AWS. The engine was used to create the parameter group name. Now the version is used correctly to select the engine version and the parameter group name is not set as the default will be correct and based on the engine version.

[#183758518](https://www.pivotaltracker.com/story/show/183758518)

### Checklist:

* [x] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

