### PR TITLE
fix: Set a name for the Aurora pgsql cluster_parameter_group

### DIFF
--- a/terraform/aurora-postgresql/provision/main.tf
+++ b/terraform/aurora-postgresql/provision/main.tf
@@ -89,6 +89,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
 resource "aws_rds_cluster_parameter_group" "cluster_parameter_group" {
   count  = length(var.db_cluster_parameter_group_name) == 0 ? 1 : 0
   family = format("aurora-postgresql%s", local.major_version)
+  name   = format("aurora-pg-%s", var.instance_name)
 
   parameter {
     name         = "rds.force_ssl"


### PR DESCRIPTION
The default Aurora Postgres cluster group parameter name is an autogenerated TF name that doesn't link back to the instance easily. E.g. terraform-20221103164025814000000001

[#183710093](https://www.pivotaltracker.com/story/show/183710093)

### Checklist:

~* [ ] Have you added Release Notes in the docs repositories?~
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

