### PR TITLE
feat: Aurora MySQL - Add aws_cloudwatch_log_group resouce

### DIFF
--- a/aws-aurora-mysql.yml
+++ b/aws-aurora-mysql.yml
@@ -125,6 +125,18 @@ provision:
       Requires setting db_cluster_parameter_group_name with a pre-created DB cluster parameter group that fulfills requirements for audit log exports. 
       See AWS Docs for more info: https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Auditing.html
       If set will enable the `audit` cloud_watch_log_export on the cluster.
+  - field_name: cloudwatch_log_group_retention_in_days
+    type: number
+    details: |
+      Used in conjunction with `enable_audit_logging`. If provided will set the retention days for the log group containing the RDS audit logs. Defaults to 30 Days.
+    default: 30
+    constraints:
+      minimum: 1
+      maximum: 3653 #10y
+  - field_name: cloudwatch_log_group_kms_key_id
+    type: string
+    default: ""
+    details: Used in conjunction with `enable_audit_logging`. If provided will set the KSM key to use for encrypting the Cloudwatch log group created for the RDS audit logs.
   - field_name: monitoring_interval
     type: number
     details: |

--- a/terraform/aurora-mysql/provision/data.tf
+++ b/terraform/aurora-mysql/provision/data.tf
@@ -16,4 +16,6 @@ locals {
 
   rds_vpc_security_group_ids = length(var.rds_vpc_security_group_ids) == 0 ? [aws_security_group.rds_sg[0].id] : split(",", var.rds_vpc_security_group_ids)
   subnet_group               = length(var.rds_subnet_group) > 0 ? var.rds_subnet_group : aws_db_subnet_group.rds_private_subnet[0].name
+
+  log_groups = var.enable_audit_logging == true ? { "audit" : true } : {}
 }

--- a/terraform/aurora-mysql/provision/main.tf
+++ b/terraform/aurora-mysql/provision/main.tf
@@ -86,3 +86,15 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
     prevent_destroy = true
   }
 }
+
+resource "aws_cloudwatch_log_group" "this" {
+  for_each = local.log_groups
+  lifecycle {
+    create_before_destroy = true
+  }
+  name              = "/aws/rds/cluster/${var.instance_name}/${each.key}"
+  retention_in_days = var.cloudwatch_log_group_retention_in_days
+  kms_key_id        = var.cloudwatch_log_group_kms_key_id == "" ? null : var.cloudwatch_log_group_kms_key_id
+
+  tags = var.labels
+}

--- a/terraform/aurora-mysql/provision/variables.tf
+++ b/terraform/aurora-mysql/provision/variables.tf
@@ -24,3 +24,5 @@ variable "monitoring_role_arn" { type = string }
 variable "performance_insights_enabled" { type = bool }
 variable "performance_insights_kms_key_id" { type = string }
 variable "performance_insights_retention_period" { type = number }
+variable "cloudwatch_log_group_retention_in_days" { type = number }
+variable "cloudwatch_log_group_kms_key_id" { type = string }


### PR DESCRIPTION
For audit logging to be enabled on updates it needs to also create the aws_cloudwatch_log_group

[#183556418](https://www.pivotaltracker.com/story/show/183556418)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

