### PR TITLE
chore: Revert aws provider bump

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -36,8 +36,8 @@ terraform_binaries:
   source: https://github.com/hashicorp/terraform/archive/v1.1.9.zip
   default: true
 - name: terraform-provider-aws
-  version: 4.39.0
-  source: https://github.com/terraform-providers/terraform-provider-aws/archive/v4.39.0.zip
+  version: 4.38.0
+  source: https://github.com/terraform-providers/terraform-provider-aws/archive/v4.38.0.zip
 - name: terraform-provider-random
   version: 3.4.3
   source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.4.3.zip

--- a/manifest.yml
+++ b/manifest.yml
@@ -36,8 +36,8 @@ terraform_binaries:
   source: https://github.com/hashicorp/terraform/archive/v1.1.9.zip
   default: true
 - name: terraform-provider-aws
-  version: 4.38.0
-  source: https://github.com/terraform-providers/terraform-provider-aws/archive/v4.38.0.zip
+  version: 4.37.0
+  source: https://github.com/terraform-providers/terraform-provider-aws/archive/v4.37.0.zip
 - name: terraform-provider-random
   version: 3.4.3
   source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.4.3.zip


### PR DESCRIPTION
Initialising the AWS provider is failing more frequently. 
It looks like this started happening after the provider was upgraded to 1.48.0

Temporarily reverting back to 1.37.0 to see if this is related. 


[#183791703](https://www.pivotaltracker.com/story/show/183791703)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

