### PR TITLE
chore: Revert aws provider bumps

### DIFF
--- a/dependency-manifest.yml
+++ b/dependency-manifest.yml
@@ -34,9 +34,9 @@ dependencies:
       source: https://github.com/hashicorp/terraform/archive/v1.1.9.zip
       source_sha256: 98e4d48e2703cff237d64a865bffba56dec597d72e40e8c978e1beccbe49c27b
     - name: terraform-provider-aws
-      version: 4.39.0
-      source: https://github.com/terraform-providers/terraform-provider-aws/archive/v4.39.0.zip
-      source_sha256: 76e46f98a1abd1fbc57580a42661c9da4b3825d78b77b4694c04abafbb26eb5f
+      version: 4.37.0
+      source: https://github.com/terraform-providers/terraform-provider-aws/archive/v4.37.0.zip
+      source_sha256: 8937f4c45b2bfa306c7a805d41998923a5f9ce956fa971150d2a9e2fd2cbd0f9
     - name: terraform-provider-csbmysql
       version: 1.0.0
       source: https://github.com/cloudfoundry/terraform-provider-csbmysql/archive/v1.0.0.zip

--- a/dependency-manifest.yml
+++ b/dependency-manifest.yml
@@ -34,9 +34,9 @@ dependencies:
       source: https://github.com/hashicorp/terraform/archive/v1.1.9.zip
       source_sha256: 98e4d48e2703cff237d64a865bffba56dec597d72e40e8c978e1beccbe49c27b
     - name: terraform-provider-aws
-      version: 4.40.0
-      source: https://github.com/terraform-providers/terraform-provider-aws/archive/v4.40.0.zip
-      source_sha256: 1553c73102ac905c689dae562b90e5fa74af3ec2ab4978218e44e618ce48482f
+      version: 4.39.0
+      source: https://github.com/terraform-providers/terraform-provider-aws/archive/v4.39.0.zip
+      source_sha256: 76e46f98a1abd1fbc57580a42661c9da4b3825d78b77b4694c04abafbb26eb5f
     - name: terraform-provider-csbmysql
       version: 1.0.0
       source: https://github.com/cloudfoundry/terraform-provider-csbmysql/archive/v1.0.0.zip

--- a/manifest.yml
+++ b/manifest.yml
@@ -36,8 +36,8 @@ terraform_binaries:
   source: https://github.com/hashicorp/terraform/archive/v1.1.9.zip
   default: true
 - name: terraform-provider-aws
-  version: 4.40.0
-  source: https://github.com/terraform-providers/terraform-provider-aws/archive/v4.40.0.zip
+  version: 4.39.0
+  source: https://github.com/terraform-providers/terraform-provider-aws/archive/v4.39.0.zip
 - name: terraform-provider-random
   version: 3.4.3
   source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.4.3.zip

--- a/manifest.yml
+++ b/manifest.yml
@@ -36,8 +36,8 @@ terraform_binaries:
   source: https://github.com/hashicorp/terraform/archive/v1.1.9.zip
   default: true
 - name: terraform-provider-aws
-  version: 4.39.0
-  source: https://github.com/terraform-providers/terraform-provider-aws/archive/v4.39.0.zip
+  version: 4.37.0
+  source: https://github.com/terraform-providers/terraform-provider-aws/archive/v4.37.0.zip
 - name: terraform-provider-random
   version: 3.4.3
   source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.4.3.zip


### PR DESCRIPTION
Provider bump is causing errors during instantiation of the AWS provider. Reverting for the moment until we investigate the issue with the error: Error: Failed to load plugin schemas Error while loading schemas for plugin components: Failed to obtain provider schema: Could not load the schema for provider registry.terraform.io/hashicorp/aws: failed to instantiate provider "registry.terraform.io/hashicorp/aws" to obtain schema: timeout while waiting for plugin to start.

[#183791703](https://www.pivotaltracker.com/story/show/183791703)

### Checklist:

~* [ ] Have you added Release Notes in the docs repositories?~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

