### PR TITLE
chore: increase brokerapp memory limit

### DIFF
--- a/cf-manifest.yml
+++ b/cf-manifest.yml
@@ -18,7 +18,7 @@
 applications:
 - name: ((app))
   command: ./cloud-service-broker serve
-  memory: 1G
+  memory: 2G
   disk_quota: 2G
   buildpacks: 
   - binary_buildpack


### PR DESCRIPTION
- apparently we use more memory when bumping the aws provider
- increasing to 2G, although haven't seen it going up 1.3G

[#183791703](https://www.pivotaltracker.com/story/show/183791703)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

