### PR TITLE
test: mark DMS endpoints with environment name

### DIFF
--- a/acceptance-tests/aurora_mysql_data_migration_test.go
+++ b/acceptance-tests/aurora_mysql_data_migration_test.go
@@ -66,7 +66,17 @@ var _ = Describe("Aurora MySQL data migration", Label("aurora-mysql-migration"),
 			Port     int    `mapstructure:"port"`
 		}
 		Expect(mapstructure.Decode(sourceCreds, &sourceReceiver)).NotTo(HaveOccurred())
-		sourceEndpoint := dms.CreateEndpoint(dms.Source, sourceReceiver.Username, sourceReceiver.Password, sourceReceiver.Server, sourceReceiver.DBName, metadata.Region, "aurora", sourceReceiver.Port)
+		sourceEndpoint := dms.CreateEndpoint(dms.CreateEndpointParams{
+			EndpointType:    dms.Source,
+			EnvironmentName: metadata.Name,
+			Username:        sourceReceiver.Username,
+			Password:        sourceReceiver.Password,
+			Server:          sourceReceiver.Server,
+			DatabaseName:    sourceReceiver.DBName,
+			Region:          metadata.Region,
+			Engine:          "aurora",
+			Port:            sourceReceiver.Port,
+		})
 		defer sourceEndpoint.Cleanup()
 
 		By("creating a DMS target endpoint")
@@ -80,7 +90,17 @@ var _ = Describe("Aurora MySQL data migration", Label("aurora-mysql-migration"),
 			Port     int    `json:"port"`
 		}
 		csbKey.Get(&targetReceiver)
-		targetEndpoint := dms.CreateEndpoint(dms.Target, targetReceiver.Username, targetReceiver.Password, targetReceiver.Server, targetReceiver.DBName, metadata.Region, "aurora", targetReceiver.Port)
+		targetEndpoint := dms.CreateEndpoint(dms.CreateEndpointParams{
+			EndpointType:    dms.Target,
+			EnvironmentName: metadata.Name,
+			Username:        targetReceiver.Username,
+			Password:        targetReceiver.Password,
+			Server:          targetReceiver.Server,
+			DatabaseName:    targetReceiver.DBName,
+			Region:          metadata.Region,
+			Engine:          "aurora",
+			Port:            targetReceiver.Port,
+		})
 		defer targetEndpoint.Cleanup()
 
 		By("running the replication task")

--- a/acceptance-tests/helpers/dms/endpoint.go
+++ b/acceptance-tests/helpers/dms/endpoint.go
@@ -17,8 +17,20 @@ type Endpoint struct {
 	region string
 }
 
-func CreateEndpoint(endpointType EndpointType, username, password, server, dbname, region, engine string, port int) *Endpoint {
-	id := random.Name()
+type CreateEndpointParams struct {
+	EndpointType    EndpointType
+	EnvironmentName string
+	Username        string
+	Password        string
+	Server          string
+	DatabaseName    string
+	Region          string
+	Engine          string
+	Port            int
+}
+
+func CreateEndpoint(params CreateEndpointParams) *Endpoint {
+	id := random.Name(random.WithPrefix(params.EnvironmentName))
 
 	var receiver struct {
 		ARN string `jsonry:"Endpoint.EndpointArn"`
@@ -29,19 +41,19 @@ func CreateEndpoint(endpointType EndpointType, username, password, server, dbnam
 		"dms",
 		"create-endpoint",
 		"--endpoint-identifier", id,
-		"--endpoint-type", string(endpointType),
-		"--engine-name", engine,
-		"--username", username,
-		"--password", password,
-		"--port", fmt.Sprintf("%d", port),
-		"--server-name", server,
-		"--database-name", dbname,
-		"--region", region,
+		"--endpoint-type", string(params.EndpointType),
+		"--engine-name", params.Engine,
+		"--username", params.Username,
+		"--password", params.Password,
+		"--port", fmt.Sprintf("%d", params.Port),
+		"--server-name", params.Server,
+		"--database-name", params.DatabaseName,
+		"--region", params.Region,
 	)
 
 	return &Endpoint{
 		arn:    receiver.ARN,
-		region: region,
+		region: params.Region,
 	}
 }
 

--- a/acceptance-tests/mysql_data_migration_test.go
+++ b/acceptance-tests/mysql_data_migration_test.go
@@ -62,7 +62,17 @@ var _ = Describe("MySQL data migration", Label("mysql-migration"), func() {
 			Port     int    `mapstructure:"port"`
 		}
 		Expect(mapstructure.Decode(sourceCreds, &sourceReceiver)).NotTo(HaveOccurred())
-		sourceEndpoint := dms.CreateEndpoint(dms.Source, sourceReceiver.Username, sourceReceiver.Password, sourceReceiver.Server, sourceReceiver.DBName, metadata.Region, "mysql", sourceReceiver.Port)
+		sourceEndpoint := dms.CreateEndpoint(dms.CreateEndpointParams{
+			EndpointType:    dms.Source,
+			EnvironmentName: metadata.Name,
+			Username:        sourceReceiver.Username,
+			Password:        sourceReceiver.Password,
+			Server:          sourceReceiver.Server,
+			DatabaseName:    sourceReceiver.DBName,
+			Region:          metadata.Region,
+			Engine:          "mysql",
+			Port:            sourceReceiver.Port,
+		})
 		defer sourceEndpoint.Cleanup()
 
 		By("creating a DMS target endpoint")
@@ -76,7 +86,17 @@ var _ = Describe("MySQL data migration", Label("mysql-migration"), func() {
 			Port     int    `json:"port"`
 		}
 		csbKey.Get(&targetReceiver)
-		targetEndpoint := dms.CreateEndpoint(dms.Target, targetReceiver.Username, targetReceiver.Password, targetReceiver.Server, targetReceiver.DBName, metadata.Region, "mysql", targetReceiver.Port)
+		targetEndpoint := dms.CreateEndpoint(dms.CreateEndpointParams{
+			EndpointType:    dms.Target,
+			EnvironmentName: metadata.Name,
+			Username:        targetReceiver.Username,
+			Password:        targetReceiver.Password,
+			Server:          targetReceiver.Server,
+			DatabaseName:    targetReceiver.DBName,
+			Region:          metadata.Region,
+			Engine:          "mysql",
+			Port:            targetReceiver.Port,
+		})
 		defer targetEndpoint.Cleanup()
 
 		By("running the replication task")

--- a/acceptance-tests/postgresql_data_migration_test.go
+++ b/acceptance-tests/postgresql_data_migration_test.go
@@ -61,7 +61,17 @@ var _ = Describe("PostgreSQL data migration", Label("postgresql-migration"), fun
 			Port     int    `mapstructure:"port"`
 		}
 		Expect(mapstructure.Decode(sourceCreds, &sourceReceiver)).NotTo(HaveOccurred())
-		sourceEndpoint := dms.CreateEndpoint(dms.Source, sourceReceiver.Username, sourceReceiver.Password, sourceReceiver.Server, sourceReceiver.DBName, metadata.Region, "postgres", sourceReceiver.Port)
+		sourceEndpoint := dms.CreateEndpoint(dms.CreateEndpointParams{
+			EndpointType:    dms.Source,
+			EnvironmentName: metadata.Name,
+			Username:        sourceReceiver.Username,
+			Password:        sourceReceiver.Password,
+			Server:          sourceReceiver.Server,
+			DatabaseName:    sourceReceiver.DBName,
+			Region:          metadata.Region,
+			Engine:          "postgres",
+			Port:            sourceReceiver.Port,
+		})
 		defer sourceEndpoint.Cleanup()
 
 		By("creating a DMS target endpoint")
@@ -75,7 +85,17 @@ var _ = Describe("PostgreSQL data migration", Label("postgresql-migration"), fun
 			Port     int    `json:"port"`
 		}
 		targetKey.Get(&targetReceiver)
-		targetEndpoint := dms.CreateEndpoint(dms.Target, targetReceiver.Username, targetReceiver.Password, targetReceiver.Server, targetReceiver.DBName, metadata.Region, "postgres", targetReceiver.Port)
+		targetEndpoint := dms.CreateEndpoint(dms.CreateEndpointParams{
+			EndpointType:    dms.Target,
+			EnvironmentName: metadata.Name,
+			Username:        targetReceiver.Username,
+			Password:        targetReceiver.Password,
+			Server:          targetReceiver.Server,
+			DatabaseName:    targetReceiver.DBName,
+			Region:          metadata.Region,
+			Engine:          "postgres",
+			Port:            targetReceiver.Port,
+		})
 		defer targetEndpoint.Cleanup()
 
 		By("running the replication task")


### PR DESCRIPTION
- tests create DMS endpoints
- this adds the environment name as a prefix to the generated name
- allows us to tell which endpoints are associated with which environment
- includes a refactor to use named parameters when creating endpoint

[#183934867](https://www.pivotaltracker.com/story/show/183934867)