### PR TITLE
test: improve matching in integration tests

### DIFF
--- a/integration-tests/integration_test_suite_test.go
+++ b/integration-tests/integration_test_suite_test.go
@@ -18,6 +18,8 @@ func TestIntegrationTests(t *testing.T) {
 const (
 	awsSecretAccessKey = "aws-secret-access-key"
 	awsAccessKeyID     = "aws-access-key-id"
+	Name               = "Name"
+	ID                 = "ID"
 )
 
 var (

--- a/integration-tests/redis_test.go
+++ b/integration-tests/redis_test.go
@@ -7,9 +7,17 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 )
 
-var _ = Describe("Redis", Label("Redis"), func() {
-	const serviceName = "csb-aws-redis"
+const (
+	redisServiceID                  = "e9c11b1b-0caa-45c9-b9b2-592939c9a5a6"
+	redisServiceName                = "csb-aws-redis"
+	redisServiceDescription         = "Beta - CSB Amazon ElastiCache for Redis - multinode with automatic failover"
+	redisServiceDisplayName         = "CSB Amazon ElastiCache for Redis (Beta)"
+	redisServiceDocumentationURL    = "https://docs.vmware.com/en/Tanzu-Cloud-Service-Broker-for-AWS/1.2/csb-aws/GUID-reference-aws-redis.html"
+	redisServiceSupportURL          = "https://aws.amazon.com/redis/"
+	redisServiceProviderDisplayName = "VMware"
+)
 
+var _ = Describe("Redis", Label("Redis"), func() {
 	BeforeEach(func() {
 		Expect(mockTerraform.SetTFState([]testframework.TFStateValue{})).To(Succeed())
 	})
@@ -22,20 +30,41 @@ var _ = Describe("Redis", Label("Redis"), func() {
 		catalog, err := broker.Catalog()
 		Expect(err).NotTo(HaveOccurred())
 
-		service := testframework.FindService(catalog, serviceName)
-		Expect(service.ID).NotTo(BeNil())
-		Expect(service.Name).NotTo(BeNil())
+		service := testframework.FindService(catalog, redisServiceName)
+		Expect(service.ID).To(Equal(redisServiceID))
+		Expect(service.Description).To(Equal(redisServiceDescription))
 		Expect(service.Tags).To(ConsistOf("aws", "redis", "beta"))
-		Expect(service.Metadata.ImageUrl).NotTo(BeNil())
-		Expect(service.Metadata.DisplayName).NotTo(BeNil())
+		Expect(service.Metadata.DisplayName).To(Equal(redisServiceDisplayName))
+		Expect(service.Metadata.DocumentationUrl).To(Equal(redisServiceDocumentationURL))
+		Expect(service.Metadata.ImageUrl).To(ContainSubstring("data:image/png;base64,"))
+		Expect(service.Metadata.SupportUrl).To(Equal(redisServiceSupportURL))
+		Expect(service.Metadata.ProviderDisplayName).To(Equal(redisServiceProviderDisplayName))
 		Expect(service.Plans).To(
 			ConsistOf(
-				MatchFields(IgnoreExtras, Fields{"Name": Equal("small")}),
-				MatchFields(IgnoreExtras, Fields{"Name": Equal("medium")}),
-				MatchFields(IgnoreExtras, Fields{"Name": Equal("large")}),
-				MatchFields(IgnoreExtras, Fields{"Name": Equal("small-ha")}),
-				MatchFields(IgnoreExtras, Fields{"Name": Equal("medium-ha")}),
-				MatchFields(IgnoreExtras, Fields{"Name": Equal("large-ha")}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("small"),
+					ID:   Equal("ad963fcd-19f7-4b79-8e6d-645756e84f7a"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("medium"),
+					ID:   Equal("df41095a-43e8-4be4-b4d6-ae2d8a35068d"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("large"),
+					ID:   Equal("da4dc49c-a64f-4d2a-8490-5e456cbb0577"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("small-ha"),
+					ID:   Equal("70544df7-0ac4-4580-ba51-c1fbdd6fdfd0"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("medium-ha"),
+					ID:   Equal("a4235008-80f4-4053-924b-defcce17cb63"),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("large-ha"),
+					ID:   Equal("f26cda6f-d4b4-473a-966c-32d238f723ef"),
+				}),
 			),
 		)
 		Expect(service.Plans).To(
@@ -50,7 +79,7 @@ var _ = Describe("Redis", Label("Redis"), func() {
 
 	Describe("provisioning", func() {
 		It("should check region constraints", func() {
-			_, err := broker.Provision(serviceName, "small", map[string]any{"region": "-Asia-northeast1"})
+			_, err := broker.Provision(redisServiceName, "small", map[string]any{"region": "-Asia-northeast1"})
 
 			Expect(err).To(MatchError(ContainSubstring("region: Does not match pattern '^[a-z][a-z0-9-]+$'")))
 		})
@@ -61,13 +90,13 @@ var _ = Describe("Redis", Label("Redis"), func() {
 
 		BeforeEach(func() {
 			var err error
-			instanceID, err = broker.Provision(serviceName, "small", nil)
+			instanceID, err = broker.Provision(redisServiceName, "small", nil)
 
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should prevent updating region because it is flagged as `prohibit_update` and it can result in the recreation of the service instance and lost data", func() {
-			err := broker.Update(instanceID, serviceName, "small", map[string]any{"region": "no-matter-what-region"})
+			err := broker.Update(instanceID, redisServiceName, "small", map[string]any{"region": "no-matter-what-region"})
 
 			Expect(err).To(MatchError(
 				ContainSubstring(

--- a/integration-tests/s3_test.go
+++ b/integration-tests/s3_test.go
@@ -9,14 +9,28 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 )
 
+const (
+	s3ServiceID                  = "ffe28d48-c235-4e07-9c51-ddff5699e48c"
+	s3ServiceName                = "csb-aws-s3-bucket"
+	s3ServiceDescription         = "CSB AWS S3 Bucket"
+	s3ServiceDisplayName         = "CSB AWS S3 Bucket"
+	s3ServiceDocumentationURL    = "https://docs.vmware.com/en/Tanzu-Cloud-Service-Broker-for-AWS/1.2/csb-aws/GUID-reference-aws-s3.html"
+	s3ServiceSupportURL          = "https://aws.amazon.com/s3/"
+	s3ServiceProviderDisplayName = "VMware"
+	s3CustomPlanName             = "custom-sample"
+	s3CustomPlanID               = "9dfa265e-1c4d-40c6-ade6-b341ffd6ccc3"
+	s3CustomPlanWithACLName      = "custom-plan-with-acl"
+	s3CustomPlanWithACLID        = "9dfa265e-1c4d-40c6-ade6-b341ffd6ccc4"
+)
+
 var customS3Plans = []map[string]any{
 	customS3Plan,
 	customS3PlanWithACL,
 }
 
 var customS3Plan = map[string]any{
-	"name":        "custom-plan",
-	"id":          "9dfa265e-1c4d-40c6-ade6-b341ffd6ccc3",
+	"name":        s3CustomPlanName,
+	"id":          s3CustomPlanID,
 	"description": "custom S3 plan defined by customer",
 	"metadata": map[string]any{
 		"displayName": "custom S3 service",
@@ -24,9 +38,9 @@ var customS3Plan = map[string]any{
 }
 
 var customS3PlanWithACL = map[string]any{
-	"name":        "custom-plan-with-acl",
+	"name":        s3CustomPlanWithACLName,
 	"acl":         "private",
-	"id":          "9dfa265e-1c4d-40c6-ade6-b341ffd6ccc4",
+	"id":          s3CustomPlanWithACLID,
 	"description": "custom S3 plan defined by customer specifying acl",
 	"metadata": map[string]any{
 		"displayName": "custom S3 service with acl",
@@ -34,7 +48,6 @@ var customS3PlanWithACL = map[string]any{
 }
 
 var _ = Describe("S3", Label("s3"), func() {
-	const s3ServiceName = "csb-aws-s3-bucket"
 	BeforeEach(func() {
 		Expect(mockTerraform.SetTFState([]testframework.TFStateValue{})).To(Succeed())
 	})
@@ -48,15 +61,24 @@ var _ = Describe("S3", Label("s3"), func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		service := testframework.FindService(catalog, s3ServiceName)
-		Expect(service.ID).NotTo(BeNil())
-		Expect(service.Name).NotTo(BeNil())
+		Expect(service.ID).To(Equal(s3ServiceID))
+		Expect(service.Description).To(Equal(s3ServiceDescription))
 		Expect(service.Tags).To(ConsistOf("aws", "s3"))
-		Expect(service.Metadata.ImageUrl).NotTo(BeNil())
-		Expect(service.Metadata.DisplayName).NotTo(BeNil())
+		Expect(service.Metadata.DisplayName).To(Equal(s3ServiceDisplayName))
+		Expect(service.Metadata.DocumentationUrl).To(Equal(s3ServiceDocumentationURL))
+		Expect(service.Metadata.ImageUrl).To(ContainSubstring("data:image/png;base64,"))
+		Expect(service.Metadata.SupportUrl).To(Equal(s3ServiceSupportURL))
+		Expect(service.Metadata.ProviderDisplayName).To(Equal(s3ServiceProviderDisplayName))
 		Expect(service.Plans).To(
 			ConsistOf(
-				MatchFields(IgnoreExtras, Fields{"Name": Equal("custom-plan")}),
-				MatchFields(IgnoreExtras, Fields{"Name": Equal("custom-plan-with-acl")}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal(s3CustomPlanName),
+					ID:   Equal(s3CustomPlanID),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal(s3CustomPlanWithACLName),
+					ID:   Equal(s3CustomPlanWithACLID),
+				}),
 			),
 		)
 	})


### PR DESCRIPTION
The integration tests contained a lot of:
```
Expect(foo).ToNot(BeNil())
```
which for a string value can never fail. These tests have been improved to match against expected data.

