### PR TITLE
chore: Bump cloud-service-broker to 0.15.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	code.cloudfoundry.org/jsonry v1.1.4
 	github.com/Pallinder/go-randomdata v1.2.0
-	github.com/cloudfoundry/cloud-service-broker v0.14.1
+	github.com/cloudfoundry/cloud-service-broker v0.15.0
 	github.com/hashicorp/terraform-json v0.14.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onsi/ginkgo/v2 v2.7.0

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudfoundry/cloud-service-broker v0.14.1 h1:OlBKOqgGlLI4OZ5/oq5eLH5cOqW9NAxfMCnbmE8V/y0=
-github.com/cloudfoundry/cloud-service-broker v0.14.1/go.mod h1:DsM2skT6bdE9jRdKMWZati9Sn7Ykr2jEWbpde0DYXjg=
+github.com/cloudfoundry/cloud-service-broker v0.15.0 h1:QUrlNQ+2b60M0i0TLv18s6L5RPHxn1wyaqt2pM5S4dQ=
+github.com/cloudfoundry/cloud-service-broker v0.15.0/go.mod h1:ScU7ufh5QJFKlwZq8e/CgiTu5YqGzA+kZa5472kaF74=
 github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e h1:FQdRViaoDphGRfgrotl2QGsX1gbloe57dbGBS5CG6KY=
 github.com/cloudfoundry/go-socks5 v0.0.0-20180221174514-54f73bdb8a8e/go.mod h1:PXmcacyJB/pJjSxEl15IU6rEIKXrhZQRzsr0UTkgNNs=
 github.com/cloudfoundry/socks5-proxy v0.2.60 h1:ydBc1njXIrCrU6UwQAwfIrKIab4Qq1lse8l2cVc7HA4=


### PR DESCRIPTION
### Checklist:

* ~[ ] Have you added Release Notes in the docs repositories?~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

