### PR TITLE
chore: Increase cf manifest disk quota

### DIFF
--- a/cf-manifest.yml
+++ b/cf-manifest.yml
@@ -19,7 +19,7 @@ applications:
 - name: ((app))
   command: ./cloud-service-broker serve
   memory: 2G
-  disk_quota: 2G
+  disk_quota: 3G
   buildpacks: 
   - binary_buildpack
   random-route: true


### PR DESCRIPTION
Acceptance tests are faling due to no space left in device. We need to further investigate the reason, and revert this commit if we can avoid increase the disk space needed in some way.

[#184401283](https://www.pivotaltracker.com/story/show/184401283)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

