### PR TITLE
fix: remove failing example after removing plans

### DIFF
--- a/aws-redis-cluster.yml
+++ b/aws-redis-cluster.yml
@@ -132,8 +132,3 @@ examples:
   plan_id: c7f64994-a1d9-4e1f-9491-9d8e56bbf146
   provision_params: {"node_type": "cache.t2.micro"}
   bind_params: {}
-- name: with-custom-node_count
-  description: Create a Redis instance with a custom node_count
-  plan_id: c7f64994-a1d9-4e1f-9491-9d8e56bbf146
-  provision_params: {"node_count": 3}
-  bind_params: {}


### PR DESCRIPTION
[#184405164](https://www.pivotaltracker.com/story/show/184405164)

After removing built-in plans an "example" plan was created and is used to run every example. But this plan specifies the node_count parameter so it can't be modified at provisioning level.

I have decided to delete the example to not saturate the marketplace and CI pipeles with several example plans with different configurations for the same service.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

