### PR TITLE
chore: remove node_count from plans

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,4 +5,4 @@ export GSB_SERVICE_CSB_AWS_POSTGRESQL_PLANS='[{"name":"default","id":"de7dbcee-1
 export GSB_SERVICE_CSB_AWS_AURORA_POSTGRESQL_PLANS='[{"name":"default","id":"d20c5cf2-29e1-11ed-93da-1f3a67a06903","description":"Default Aurora Postgres plan","display_name":"default"}]'
 export GSB_SERVICE_CSB_AWS_AURORA_MYSQL_PLANS='[{"name":"default","id":"10b2bd92-2a0b-11ed-b70f-c7c5cf3bb719","description":"Default Aurora MySQL plan","display_name":"default"}]'
 export GSB_SERVICE_CSB_AWS_MYSQL_PLANS='[{"name":"default","id":"0f3522b2-f040-443b-bc53-4aed25284840","description":"Default MySQL plan","display_name":"default","instance_class":"db.m6i.large","mysql_version":"8.0","storage_gb":100}]'
-export GSB_SERVICE_CSB_AWS_REDIS_PLANS='[{"name":"default", "id":"c7f64994-a1d9-4e1f-9491-9d8e56bbf146","description":"Default Redis plan","display_name":"default","cache_size":2,"node_count":2,"redis_version": "6.0"}]'
+export GSB_SERVICE_CSB_AWS_REDIS_PLANS='[{"name":"default", "id":"c7f64994-a1d9-4e1f-9491-9d8e56bbf146","description":"Default Redis plan","display_name":"default","cache_size":2,"redis_version": "6.0"}]'

--- a/acceptance-tests/helpers/brokers/env.go
+++ b/acceptance-tests/helpers/brokers/env.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	PlansRedisVar    = "GSB_SERVICE_CSB_AWS_REDIS_PLANS"
-	defaultRedisPlan = `[{"name":"default", "id":"c7f64994-a1d9-4e1f-9491-9d8e56bbf146","description":"Default Redis plan","display_name":"default","cache_size":2,"node_count":2,"redis_version": "7.0"}]`
+	defaultRedisPlan = `[{"name":"default","id":"c7f64994-a1d9-4e1f-9491-9d8e56bbf146","description":"Default Redis plan","display_name":"default","cache_size":2,"redis_version":"7.0"}]`
 )
 
 func (b Broker) env() []apps.EnvVar {

--- a/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Redis", Label("redis"), func() {
 			By("pushing the development version of the broker")
 			serviceBroker.UpdateBroker(developmentBuildDir, apps.EnvVar{
 				Name:  brokers.PlansRedisVar, // at_rest_encryption_enabled=false for upgrade
-				Value: `[{"name":"default","id":"c7f64994-a1d9-4e1f-9491-9d8e56bbf146","description":"Default Redis plan","display_name":"default","cache_size":2,"node_count":2,"redis_version":"7.0","at_rest_encryption_enabled":false}]`,
+				Value: `[{"name":"default","id":"c7f64994-a1d9-4e1f-9491-9d8e56bbf146","description":"Default Redis plan","display_name":"default","cache_size":2,"redis_version":"7.0","at_rest_encryption_enabled":false}]`,
 			})
 
 			By("upgrading service instance")


### PR DESCRIPTION
The default value for node_count is 2, so there's no need to explicitly set it in any plans

[#184651843](https://www.pivotaltracker.com/story/show/184651843)