### PR TITLE
chore: fix redis upgrade tests

### DIFF
--- a/acceptance-tests/helpers/brokers/env.go
+++ b/acceptance-tests/helpers/brokers/env.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	PlansRedisVar    = "GSB_SERVICE_CSB_AWS_REDIS_PLANS"
-	defaultRedisPlan = `[{"name":"default","id":"c7f64994-a1d9-4e1f-9491-9d8e56bbf146","description":"Default Redis plan","display_name":"default","node_type":"cache.t3.medium","redis_version":"7.0"}]`
+	plansRedisVar              = "GSB_SERVICE_CSB_AWS_REDIS_PLANS"
+	defaultRedisPlanForUpgrade = `{"name":"default","id":"c7f64994-a1d9-4e1f-9491-9d8e56bbf146","description":"Default Redis plan","display_name":"default","node_type":"cache.t3.medium","redis_version":"7.0", "at_rest_encryption_enabled": false, "multi_az_enabled": false}`
+	oldRedisPlanForUpgrade     = `{"name": "small", "id": "ad963fcd-19f7-4b79-8e6d-645756e84f7a","description": "Beta - Redis 6.0 with 1GB cache and 1 node.","cache_size": 2,"redis_version": "6.0","node_count": 1,"at_rest_encryption_enabled": false, "multi_az_enabled": false}`
 )
 
 func (b Broker) env() []apps.EnvVar {
@@ -63,7 +64,7 @@ func (b Broker) releaseEnv() []apps.EnvVar {
 
 func (b Broker) latestEnv() []apps.EnvVar {
 	return []apps.EnvVar{
-		{Name: PlansRedisVar, Value: defaultRedisPlan},
+		{Name: plansRedisVar, Value: fmt.Sprintf(`[%s, %s]`, defaultRedisPlanForUpgrade, oldRedisPlanForUpgrade)},
 	}
 }
 

--- a/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
@@ -56,10 +56,7 @@ var _ = Describe("Redis", Label("redis"), func() {
 			Expect(appTwo.GET(key)).To(Equal(value))
 
 			By("pushing the development version of the broker")
-			serviceBroker.UpdateBroker(developmentBuildDir, apps.EnvVar{
-				Name:  brokers.PlansRedisVar, // at_rest_encryption_enabled=false for upgrade
-				Value: `[{"name":"default","id":"c7f64994-a1d9-4e1f-9491-9d8e56bbf146","description":"Default Redis plan","display_name":"default","node_type":"cache.t3.medium","redis_version":"7.0","at_rest_encryption_enabled":false}]`,
-			})
+			serviceBroker.UpdateBroker(developmentBuildDir)
 
 			By("upgrading service instance")
 			serviceInstance.Upgrade()


### PR DESCRIPTION
Instances from plans that have been deactivated don't get upgraded. This commit adds the small plan to the latest broker so it doesn't get deactivated and the instance gets upgraded if the upgrade is available

latestEnv in the env.go file is only used when doing upgrade tests and withoutCredhub. In the first case we need plans that make sense during upgrade, in the second scenario, we don't care what the plans look like.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

