### PR TITLE
test: replace gorilla/mux with chi in test app

### DIFF
--- a/acceptance-tests/apps/postgresqlapp/go.mod
+++ b/acceptance-tests/apps/postgresqlapp/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/cloudfoundry-community/go-cfenv v1.18.0
-	github.com/gorilla/mux v1.8.0
+	github.com/go-chi/chi/v5 v5.0.8
 	github.com/jackc/pgx/v4 v4.18.1
 	github.com/mitchellh/mapstructure v1.5.0
 )

--- a/acceptance-tests/apps/postgresqlapp/go.sum
+++ b/acceptance-tests/apps/postgresqlapp/go.sum
@@ -12,6 +12,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=
+github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -28,8 +30,6 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=

--- a/acceptance-tests/apps/postgresqlapp/internal/app/drop_schema.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/drop_schema.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-
 	"postgresqlapp/internal/connector"
 )
 
@@ -12,13 +11,18 @@ func handleDropSchema(conn *connector.Connector) func(w http.ResponseWriter, r *
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Handling drop schema.")
 
+		schema, err := schemaName(r)
+		if err != nil {
+			fail(w, http.StatusBadRequest, "schema name error: %s", err)
+			return
+		}
+
 		db, err := conn.Connect(connector.WithTLS(r.URL.Query().Get(tlsQueryParam)))
 		if err != nil {
 			fail(w, http.StatusInternalServerError, "failed to connect to database: %e", err)
 		}
 		defer db.Close()
 
-		schema := r.Context().Value(schemaKey)
 		_, err = db.Exec(fmt.Sprintf(`DROP SCHEMA %s CASCADE`, schema))
 		if err != nil {
 			fail(w, http.StatusBadRequest, "Error dropping schema: %s", err)

--- a/acceptance-tests/apps/postgresqlapp/internal/app/get.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/get.go
@@ -4,28 +4,32 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-
-	"github.com/gorilla/mux"
-
 	"postgresqlapp/internal/connector"
+
+	"github.com/go-chi/chi/v5"
 )
 
 func handleGet(conn *connector.Connector) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Handling get.")
 
+		schema, err := schemaName(r)
+		if err != nil {
+			fail(w, http.StatusBadRequest, "schema name error: %s", err)
+			return
+		}
+
+		key := chi.URLParam(r, "key")
+		if key == "" {
+			fail(w, http.StatusBadRequest, "key must be supplied")
+			return
+		}
+
 		db, err := conn.Connect(connector.WithTLS(r.URL.Query().Get(tlsQueryParam)))
 		if err != nil {
 			fail(w, http.StatusInternalServerError, "failed to connect to database: %s", err.Error())
 		}
 		defer db.Close()
-
-		schema := r.Context().Value(schemaKey)
-		key, ok := mux.Vars(r)["key"]
-		if !ok {
-			fail(w, http.StatusBadRequest, "Key missing.")
-			return
-		}
 
 		stmt, err := db.Prepare(fmt.Sprintf(`SELECT %s from %s.%s WHERE %s = $1`, valueColumn, schema, tableName, keyColumn))
 		if err != nil {


### PR DESCRIPTION
gorilla/mux has been archived and subsequently removed from most test apps. The postgresql test app is sufficiently complex that a framework is needed in addition to the standard "net/http" package.

chi was chosen because of it plays well with "net/http" and has been the replacement for gorilla/mux in a number of other CloudFoundry projects

[#184006000](https://www.pivotaltracker.com/story/show/184006000)
