### PR TITLE
feat(dynamodb): add separator at end of prefix

### DIFF
--- a/aws-dynamodb-namespace.yml
+++ b/aws-dynamodb-namespace.yml
@@ -36,7 +36,7 @@ provision:
   - name: prefix
     type: string
     details: Prefix for the DynamoDB table names
-    default: csb-${request.instance_id}
+    default: "csb-${request.instance_id}-"
   - name: region
     type: string
     details: Region for the DynamoDB tables

--- a/integration-tests/aurora_mysql_test.go
+++ b/integration-tests/aurora_mysql_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Aurora MySQL", Label("aurora-mysql"), func() {
 				HaveKeyWithValue("instance_name", fmt.Sprintf("csb-auroramysql-%s", instanceID)),
 				HaveKeyWithValue("cluster_instances", BeNumerically("==", 3)),
 				HaveKeyWithValue("db_name", "csbdb"),
-				HaveKeyWithValue("region", "us-west-2"),
+				HaveKeyWithValue("region", fakeRegion),
 				HaveKeyWithValue("allow_major_version_upgrade", BeTrue()),
 				HaveKeyWithValue("auto_minor_version_upgrade", BeTrue()),
 				HaveKeyWithValue("rds_vpc_security_group_ids", BeEmpty()),

--- a/integration-tests/aurora_postgresql_test.go
+++ b/integration-tests/aurora_postgresql_test.go
@@ -132,7 +132,7 @@ var _ = Describe("Aurora PostgreSQL", Label("aurora-postgresql"), func() {
 					HaveKeyWithValue("instance_name", fmt.Sprintf("csb-aurorapg-%s", instanceID)),
 					HaveKeyWithValue("cluster_instances", BeNumerically("==", 3)),
 					HaveKeyWithValue("db_name", "csbdb"),
-					HaveKeyWithValue("region", "us-west-2"),
+					HaveKeyWithValue("region", fakeRegion),
 					HaveKeyWithValue("allow_major_version_upgrade", BeTrue()),
 					HaveKeyWithValue("auto_minor_version_upgrade", BeTrue()),
 					HaveKeyWithValue("rds_vpc_security_group_ids", BeEmpty()),

--- a/integration-tests/dynamodb_namespace_test.go
+++ b/integration-tests/dynamodb_namespace_test.go
@@ -1,0 +1,65 @@
+package integration_test
+
+import (
+	"fmt"
+
+	testframework "github.com/cloudfoundry/cloud-service-broker/brokerpaktestframework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+const (
+	dynamoDBNamespaceServiceID                  = "07d06aeb-f87a-4e06-90ae-0b07a8c21a02"
+	dynamoDBNamespaceServiceName                = "csb-aws-dynamodb-namespace"
+	dynamoDBNamespaceServiceDescription         = "CSB Amazon DynamoDB Namespace"
+	dynamoDBNamespaceServiceDisplayName         = "CSB Amazon DynamoDB Namespace"
+	dynamoDBNamespaceServiceDocumentationURL    = "https://docs.vmware.com/en/Tanzu-Cloud-Service-Broker-for-AWS/1.5/csb-aws/GUID-reference-aws-dynamodb-namespace.html"
+	dynamoDBNamespaceServiceSupportURL          = "https://aws.amazon.com/dynamodb/"
+	dynamoDBNamespaceServiceProviderDisplayName = "VMware"
+)
+
+var _ = Describe("DynamoDB Namespace", Label("DynamoDB Namespace"), func() {
+	BeforeEach(func() {
+		Expect(mockTerraform.SetTFState([]testframework.TFStateValue{})).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(mockTerraform.Reset()).To(Succeed())
+	})
+
+	It("should publish the service in the catalog", func() {
+		catalog, err := broker.Catalog()
+		Expect(err).NotTo(HaveOccurred())
+
+		service := testframework.FindService(catalog, dynamoDBNamespaceServiceName)
+		Expect(service.ID).To(Equal(dynamoDBNamespaceServiceID))
+		Expect(service.Description).To(Equal(dynamoDBNamespaceServiceDescription))
+		Expect(service.Tags).To(ConsistOf("aws", "dynamodb", "namespace"))
+		Expect(service.Metadata.DisplayName).To(Equal(dynamoDBNamespaceServiceDisplayName))
+		Expect(service.Metadata.DocumentationUrl).To(Equal(dynamoDBNamespaceServiceDocumentationURL))
+		Expect(service.Metadata.ImageUrl).To(ContainSubstring("data:image/png;base64,"))
+		Expect(service.Metadata.SupportUrl).To(Equal(dynamoDBNamespaceServiceSupportURL))
+		Expect(service.Metadata.ProviderDisplayName).To(Equal(dynamoDBNamespaceServiceProviderDisplayName))
+		Expect(service.Plans).To(
+			ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					Name: Equal("default"),
+					ID:   Equal("73b55e9a-4cdd-4d6f-81bd-c34d5c27a086"),
+				}),
+			),
+		)
+	})
+
+	Describe("provisioning", func() {
+		It("should provision an instance", func() {
+			instanceID, err := broker.Provision(dynamoDBNamespaceServiceName, "default", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mockTerraform.FirstTerraformInvocationVars()).To(SatisfyAll(
+				HaveKeyWithValue("prefix", fmt.Sprintf("csb-%s-", instanceID)),
+				HaveKeyWithValue("region", fakeRegion),
+			))
+		})
+	})
+})

--- a/integration-tests/integration_test_suite_test.go
+++ b/integration-tests/integration_test_suite_test.go
@@ -20,6 +20,7 @@ const (
 	awsAccessKeyID     = "aws-access-key-id"
 	Name               = "Name"
 	ID                 = "ID"
+	fakeRegion         = "fake-region"
 )
 
 var (
@@ -46,6 +47,7 @@ var _ = BeforeSuite(func() {
 		"AWS_SECRET_ACCESS_KEY=" + awsSecretAccessKey,
 		"CSB_LISTENER_HOST=localhost",
 		"GSB_COMPATIBILITY_ENABLE_BETA_SERVICES=true",
+		"GSB_PROVISION_DEFAULTS=" + marshall(map[string]string{"region": fakeRegion}),
 	})).To(Succeed())
 })
 

--- a/integration-tests/mysql_test.go
+++ b/integration-tests/mysql_test.go
@@ -135,7 +135,7 @@ var _ = Describe("MySQL", Label("MySQL"), func() {
 					HaveKeyWithValue("instance_name", fmt.Sprintf("csb-mysql-%s", instanceID)),
 					HaveKeyWithValue("db_name", "vsbdb"),
 					HaveKeyWithValue("publicly_accessible", false),
-					HaveKeyWithValue("region", "us-west-2"),
+					HaveKeyWithValue("region", fakeRegion),
 					HaveKeyWithValue("multi_az", true),
 					HaveKeyWithValue("instance_class", ""),
 					HaveKeyWithValue("rds_subnet_group", ""),

--- a/integration-tests/postgresql_test.go
+++ b/integration-tests/postgresql_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 					HaveKeyWithValue("instance_name", fmt.Sprintf("csb-postgresql-%s", instanceID)),
 					HaveKeyWithValue("db_name", "vsbdb"),
 					HaveKeyWithValue("publicly_accessible", false),
-					HaveKeyWithValue("region", "us-west-2"),
+					HaveKeyWithValue("region", fakeRegion),
 					HaveKeyWithValue("storage_encrypted", false),
 					HaveKeyWithValue("kms_key_id", ""),
 					HaveKeyWithValue("multi_az", false),

--- a/integration-tests/redis_test.go
+++ b/integration-tests/redis_test.go
@@ -238,7 +238,7 @@ var _ = Describe("Redis", Label("Redis"), func() {
 				SatisfyAll(
 					HaveKey("instance_name"),
 					HaveKeyWithValue("labels", HaveKeyWithValue("pcf-instance-id", instanceID)),
-					HaveKeyWithValue("region", "us-west-2"),
+					HaveKeyWithValue("region", fakeRegion),
 					HaveKeyWithValue("cache_size", BeNil()),
 					HaveKeyWithValue("node_count", BeNumerically("==", 2)),
 					HaveKeyWithValue("redis_version", "6.x"),

--- a/integration-tests/s3_test.go
+++ b/integration-tests/s3_test.go
@@ -93,7 +93,7 @@ var _ = Describe("S3", Label("s3"), func() {
 					HaveKeyWithValue("bucket_name", "csb-"+instanceID),
 					HaveKeyWithValue("enable_versioning", false),
 					HaveKeyWithValue("labels", HaveKeyWithValue("pcf-instance-id", instanceID)),
-					HaveKeyWithValue("region", "us-west-2"),
+					HaveKeyWithValue("region", fakeRegion),
 					HaveKeyWithValue("acl", BeNil()),
 					HaveKeyWithValue("ol_enabled", false),
 					HaveKeyWithValue("ol_configuration_default_retention_enabled", BeNil()),

--- a/terraform-tests/dynamodb_namespace_test.go
+++ b/terraform-tests/dynamodb_namespace_test.go
@@ -22,7 +22,7 @@ var _ = Describe("dynamodb-namespace", Label("dynamodb-ns-terraform"), Ordered, 
 			terraformProvisionDir = path.Join(workingDir, "dynamodb-namespace/provision")
 			defaultVars = map[string]any{
 				"region": "fake-region",
-				"prefix": "csb-fake-5368-489c-9f18-b53140316fb2",
+				"prefix": "csb-fake-5368-489c-9f18-b53140316fb2-",
 			}
 			Init(terraformProvisionDir)
 		})
@@ -40,7 +40,7 @@ var _ = Describe("dynamodb-namespace", Label("dynamodb-ns-terraform"), Ordered, 
 				Expect(plan.OutputChanges).To(HaveKeyWithValue("region", BeAssignableToTypeOf(&tfjson.Change{})))
 				Expect(plan.OutputChanges).To(HaveKeyWithValue("prefix", BeAssignableToTypeOf(&tfjson.Change{})))
 				Expect(plan.OutputChanges["region"].After).To(Equal("fake-region"))
-				Expect(plan.OutputChanges["prefix"].After).To(Equal("csb-fake-5368-489c-9f18-b53140316fb2"))
+				Expect(plan.OutputChanges["prefix"].After).To(Equal("csb-fake-5368-489c-9f18-b53140316fb2-"))
 			})
 		})
 	})
@@ -50,7 +50,7 @@ var _ = Describe("dynamodb-namespace", Label("dynamodb-ns-terraform"), Ordered, 
 			terraformProvisionDir = path.Join(workingDir, "dynamodb-namespace/bind")
 			defaultVars = map[string]any{
 				"user_name":             "fake-user-name",
-				"prefix":                "csb-fake-5368-489c-9f18-b53140316fb2",
+				"prefix":                "csb-fake-5368-489c-9f18-b53140316fb2-",
 				"region":                "us-west-1",
 				"aws_access_key_id":     awsAccessKeyID,
 				"aws_secret_access_key": awsSecretAccessKey,


### PR DESCRIPTION
To make it easier to read table names, the dynamodb prefix has been updated from "csb-GUID" to "csb-GUID-" so that table names will be of the form "csb-GUID-example_table" and it will be easier to distinguish between the prefix and the table name.

[#184866266](https://www.pivotaltracker.com/story/show/184866266)
