### PR TITLE
feat: defaults when node_count is 1

### DIFF
--- a/aws-redis.yml
+++ b/aws-redis.yml
@@ -109,7 +109,7 @@ provision:
     prohibit_update: true
   - field_name: multi_az_enabled
     type: boolean
-    details: Whether to enable Multi-AZ Support for the replication group. If true, `node_count` must be greater than 1.
+    details: Whether to enable Multi-AZ Support for the replication group. Only applies when `node_count` is greater than 1.
     default: true
   - field_name: kms_key_id
     type: string
@@ -118,7 +118,7 @@ provision:
     prohibit_update: true
   - field_name: automatic_failover_enabled
     type: boolean
-    details: Automatically promote replica to primary if the existing primary fails. If enabled, node_count must be greater than 1.
+    details: Automatically promote replica to primary if the existing primary fails. Only applies when `node_count` is greater than 1.
     default: true
   - <<: &nullable_string
       type: string

--- a/terraform/redis/cluster/provision/main.tf
+++ b/terraform/redis/cluster/provision/main.tf
@@ -44,8 +44,8 @@ resource "random_password" "auth_token" {
 }
 
 resource "aws_elasticache_replication_group" "redis" {
-  automatic_failover_enabled  = var.automatic_failover_enabled
-  multi_az_enabled            = var.multi_az_enabled
+  automatic_failover_enabled  = var.node_count == 1 ? false : var.automatic_failover_enabled
+  multi_az_enabled            = var.node_count == 1 ? false : var.multi_az_enabled
   replication_group_id        = var.instance_name
   description                 = format("%s redis", var.instance_name)
   node_type                   = local.node_type


### PR DESCRIPTION
When node_count == 1, the multi_az_enabled and
automatic_failover_enabled properties must be false. During testing of upgrades, we found that this could be problematic for automatic_failover_enabled.

In previous versions automatic_failover_enabled was false when node_count was 1 and true otherwise. It was not exposed as a property.

We had a desire to expose automatic_failover_enabled and multi_az_enabled as properties, and to remove this defaulting behaviour so that users could be clear that when they set multi_az_enabled or automatic_failover_enabled it would apply, or there would be a failure.

But considering upgrades, there is a scenario where a plan allows the user to set the node_count. When upgrading this plan, so instances would need `automatic_failover_enabled: false` in order to upgrade successfully and some would not. The upgrade process does not allow properties to be changed, leading to a unhappy upgrade process.

So we decided that automatic_failover_enabled should be false when the node_count is 1. For consistency we have done the same for multi_az_enabled, although this property was not problematic.

[#184869846](https://www.pivotaltracker.com/story/show/184869846)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

