### PR TITLE
fix: add environment variable to execute TF upgrade

### DIFF
--- a/acceptance-tests/helpers/brokers/env.go
+++ b/acceptance-tests/helpers/brokers/env.go
@@ -1,9 +1,10 @@
 package brokers
 
 import (
-	"csbbrokerpakaws/acceptance-tests/helpers/testpath"
 	"fmt"
 	"os"
+
+	"csbbrokerpakaws/acceptance-tests/helpers/testpath"
 
 	"csbbrokerpakaws/acceptance-tests/helpers/apps"
 
@@ -43,6 +44,7 @@ func (b Broker) env() []apps.EnvVar {
 		apps.EnvVar{Name: "GSB_PROVISION_DEFAULTS", Value: fmt.Sprintf(`{"aws_vpc_id": %q}`, os.Getenv("AWS_PAS_VPC_ID"))},
 		apps.EnvVar{Name: "GSB_COMPATIBILITY_ENABLE_BETA_SERVICES", Value: true},
 		apps.EnvVar{Name: "TERRAFORM_UPGRADES_ENABLED", Value: true},
+		apps.EnvVar{Name: "CSB_DISABLE_TF_UPGRADE_PROVIDER_RENAMES", Value: true},
 	)
 
 	return append(result, b.envExtras...)


### PR DESCRIPTION
We need the renaming of TF in the acceptance tests. The acceptance tests do not read the full .envrc file, only the service plans.

[#184670887](https://www.pivotaltracker.com/story/show/184670887)

### Checklist:

* ~~[ ] Have you added Release Notes in the docs repositories?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

