### PR TITLE
test: avoid timeout in DynamoDB

### DIFF
--- a/providers/terraform-provider-csbdynamodbns/resource_dynamodb_instance_test.go
+++ b/providers/terraform-provider-csbdynamodbns/resource_dynamodb_instance_test.go
@@ -29,6 +29,11 @@ var _ = Describe("Resource dynamodbns_instance", func() {
 		localDynamoDBURL = fmt.Sprintf("http://127.0.0.1:%d", port)
 		prefix = fmt.Sprintf("csb-%s-", uuid.New())
 
+		pullCMD := exec.Command("docker", "pull", "amazon/dynamodb-local")
+		sessionDockerPull, err := gexec.Start(pullCMD, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(sessionDockerPull).WithTimeout(time.Minute).WithPolling(time.Second).Should(gexec.Exit(0))
+
 		cmd := exec.Command("docker", "run",
 			"-p", fmt.Sprintf("%d:8000", port),
 			"-t", "amazon/dynamodb-local")


### PR DESCRIPTION
Downloading the Docker images was usually taking longer than the specified timeout. We run docker pull with a different session to overcome this issue.

### Checklist:

* ~~[ ] Have you added Release Notes in the docs repositories?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

