### PR TITLE
fix: [AWS] removed prop in Terraform Redis resource

### DIFF
--- a/terraform-tests/redis_test.go
+++ b/terraform-tests/redis_test.go
@@ -104,7 +104,6 @@ var _ = Describe("Redis", Label("redis-terraform"), Ordered, func() {
 					"notification_topic_arn":     BeNil(),
 					"timeouts":                   BeNil(),
 					"log_delivery_configuration": BeAssignableToTypeOf([]any{}),
-					"availability_zones":         BeNil(),
 					"multi_az_enabled":           BeAssignableToTypeOf(false),
 					"snapshot_arns":              BeNil(),
 					"tags_all":                   BeAssignableToTypeOf(map[string]any{}),


### PR DESCRIPTION
[#185273812]

availability_zones has been deprecated for some time in latest version of the aws terraform provider this property has been removed.

It doesn't impact the service in any way. Tests were failing because we were proactively checking for any possible changes in all properties (even the ones we are not using).

### Checklist:

* ~~[ ] Have you added Release Notes in the docs repositories?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

