### PR TITLE
chore: workaround issue with passwords with leading dashes in migration

### DIFF
--- a/acceptance-tests/helpers/dms/endpoint.go
+++ b/acceptance-tests/helpers/dms/endpoint.go
@@ -44,7 +44,7 @@ func CreateEndpoint(params CreateEndpointParams) *Endpoint {
 		"--endpoint-type", string(params.EndpointType),
 		"--engine-name", params.Engine,
 		"--username", params.Username,
-		"--password", params.Password,
+		fmt.Sprintf("--password=%s", params.Password), // workaround for passwords starting with dashes as suggested in https://github.com/aws/aws-cli/issues/1135#issuecomment-77254897
 		"--port", fmt.Sprintf("%d", params.Port),
 		"--server-name", params.Server,
 		"--database-name", params.DatabaseName,


### PR DESCRIPTION
test.

aws cli has issues with argument parsing with arguments with leading dashes
this change implements workaround proposed here https://github.com/aws/aws-cli/issues/1135#issuecomment-77254897

[#185541709](https://www.pivotaltracker.com/story/show/185541709)

### Checklist:

~~ * [ ] Have you added Release Notes in the docs repositories?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

