### PR TITLE
chore: Revert "chore: insufficient "disk" in acceptance tests (#990)"

### DIFF
--- a/acceptance-tests/dynamodb_namespace_data_migration_test.go
+++ b/acceptance-tests/dynamodb_namespace_data_migration_test.go
@@ -32,7 +32,7 @@ var _ = Describe("DynamoDB Namespace Data Migration", Label("dynamodb-namespace-
 		defer csbServiceInstance.Delete()
 
 		By("pushing and binding an app")
-		app := apps.Push(apps.WithApp(apps.DynamoDBNamespace), apps.WithDisk("2G"), apps.WithMemory("100M"))
+		app := apps.Push(apps.WithApp(apps.DynamoDBNamespace))
 		defer apps.Delete(app)
 		legacyBinding := legacyServiceInstance.Bind(app)
 		apps.Start(app)

--- a/acceptance-tests/dynamodb_table_test.go
+++ b/acceptance-tests/dynamodb_table_test.go
@@ -20,8 +20,8 @@ var _ = Describe("DynamoDB Table", Label("dynamodb-table"), func() {
 		defer serviceInstance.Delete()
 
 		By("pushing the unstarted app twice")
-		appOne := apps.Push(apps.WithApp(apps.DynamoDBTable), apps.WithDisk("2G"), apps.WithMemory("100M"))
-		appTwo := apps.Push(apps.WithApp(apps.DynamoDBTable), apps.WithDisk("2G"), apps.WithMemory("100M"))
+		appOne := apps.Push(apps.WithApp(apps.DynamoDBTable))
+		appTwo := apps.Push(apps.WithApp(apps.DynamoDBTable))
 		defer apps.Delete(appOne, appTwo)
 
 		By("binding the apps to the DynamoDB Table service instance")

--- a/acceptance-tests/helpers/apps/app.go
+++ b/acceptance-tests/helpers/apps/app.go
@@ -9,5 +9,4 @@ type App struct {
 	memory    string
 	manifest  string
 	dir       dir
-	disk      string
 }

--- a/acceptance-tests/helpers/apps/push.go
+++ b/acceptance-tests/helpers/apps/push.go
@@ -31,9 +31,6 @@ func (a *App) Push(opts ...Option) {
 	if a.buildpack != "" {
 		cmd = append(cmd, "-b", a.buildpack)
 	}
-	if a.disk != "" {
-		cmd = append(cmd, "-k", a.disk)
-	}
 	if a.memory != "" {
 		cmd = append(cmd, "-m", a.memory)
 	}
@@ -84,21 +81,9 @@ func WithDir(dir string) Option {
 	}
 }
 
-func WithDisk(disk string) Option {
-	return func(a *App) {
-		a.disk = disk
-	}
-}
-
 func WithManifest(manifest string) Option {
 	return func(a *App) {
 		a.manifest = manifest
-	}
-}
-
-func WithMemory(memory string) Option {
-	return func(a *App) {
-		a.memory = memory
 	}
 }
 

--- a/acceptance-tests/upgrade/update_and_upgrade_aurora_mysql_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_aurora_mysql_test.go
@@ -36,8 +36,8 @@ var _ = Describe("UpgradeAuroraMySQLTest", Label("aurora-mysql", "upgrade"), fun
 			defer serviceInstance.Delete()
 
 			By("pushing the unstarted app twice")
-			appOne := apps.Push(apps.WithApp(apps.MySQL), apps.WithDisk("2G"))
-			appTwo := apps.Push(apps.WithApp(apps.MySQL), apps.WithDisk("2G"))
+			appOne := apps.Push(apps.WithApp(apps.MySQL))
+			appTwo := apps.Push(apps.WithApp(apps.MySQL))
 			defer apps.Delete(appOne, appTwo)
 
 			By("binding to the apps")

--- a/acceptance-tests/upgrade/update_and_upgrade_aurora_postgresql_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_aurora_postgresql_test.go
@@ -38,8 +38,8 @@ var _ = Describe("UpgradeAuroraPostgreSQLTest", Label("aurora-postgresql", "upgr
 			defer serviceInstance.Delete()
 
 			By("pushing the unstarted app twice")
-			appOne := apps.Push(apps.WithApp(apps.PostgreSQL), apps.WithDisk("2G"))
-			appTwo := apps.Push(apps.WithApp(apps.PostgreSQL), apps.WithDisk("2G"))
+			appOne := apps.Push(apps.WithApp(apps.PostgreSQL))
+			appTwo := apps.Push(apps.WithApp(apps.PostgreSQL))
 			defer apps.Delete(appOne, appTwo)
 
 			By("binding to the apps")

--- a/acceptance-tests/upgrade/update_and_upgrade_dynamodb_table_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_dynamodb_table_test.go
@@ -33,8 +33,8 @@ var _ = Describe("UpgradeDynamoDBTableTest", Label("dynamodb-table", "upgrade"),
 			defer serviceInstance.Delete()
 
 			By("pushing the unstarted app twice")
-			appOne := apps.Push(apps.WithApp(apps.DynamoDBTable), apps.WithDisk("2G"))
-			appTwo := apps.Push(apps.WithApp(apps.DynamoDBTable), apps.WithDisk("2G"))
+			appOne := apps.Push(apps.WithApp(apps.DynamoDBTable))
+			appTwo := apps.Push(apps.WithApp(apps.DynamoDBTable))
 			defer apps.Delete(appOne, appTwo)
 
 			By("binding the apps to the DynamoDB Table service instance")

--- a/acceptance-tests/upgrade/update_and_upgrade_mysql_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mysql_test.go
@@ -38,8 +38,8 @@ var _ = Describe("UpgradeMySQLTest", Label("mysql", "upgrade"), func() {
 			defer serviceInstance.Delete()
 
 			By("pushing the unstarted app twice")
-			appOne := apps.Push(apps.WithApp(apps.MySQL), apps.WithDisk("2G"))
-			appTwo := apps.Push(apps.WithApp(apps.MySQL), apps.WithDisk("2G"))
+			appOne := apps.Push(apps.WithApp(apps.MySQL))
+			appTwo := apps.Push(apps.WithApp(apps.MySQL))
 			defer apps.Delete(appOne, appTwo)
 
 			By("binding to the apps")

--- a/acceptance-tests/upgrade/update_and_upgrade_postgresql_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_postgresql_test.go
@@ -38,8 +38,8 @@ var _ = Describe("UpgradePostgreSQLTest", Label("postgresql", "upgrade"), func()
 			defer serviceInstance.Delete()
 
 			By("pushing the unstarted app twice")
-			appOne := apps.Push(apps.WithApp(apps.PostgreSQL), apps.WithDisk("2G"))
-			appTwo := apps.Push(apps.WithApp(apps.PostgreSQL), apps.WithDisk("2G"))
+			appOne := apps.Push(apps.WithApp(apps.PostgreSQL))
+			appTwo := apps.Push(apps.WithApp(apps.PostgreSQL))
 			defer apps.Delete(appOne, appTwo)
 
 			By("binding to the apps")

--- a/acceptance-tests/upgrade/update_and_upgrade_s3_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_s3_test.go
@@ -30,8 +30,8 @@ var _ = Describe("UpgradeS3Test", Label("upgrade", "s3"), func() {
 			defer serviceInstance.Delete()
 
 			By("pushing the unstarted app twice")
-			appOne := apps.Push(apps.WithApp(apps.S3), apps.WithDisk("2G"))
-			appTwo := apps.Push(apps.WithApp(apps.S3), apps.WithDisk("2G"))
+			appOne := apps.Push(apps.WithApp(apps.S3))
+			appTwo := apps.Push(apps.WithApp(apps.S3))
 			defer apps.Delete(appOne, appTwo)
 
 			By("binding the apps to the s3 service instance")


### PR DESCRIPTION
This reverts commit ab94c6b46eff54511574a4a7fb1f94fcf934ecdf.

Reason for `insufficient disk` error was total diego cell available disk and not specific apps needing more space. We increased compute instance size in our pool for now. We'll try to reduce the amount of disk needed in future improvements.

[#185528524]

### Checklist:

~~* [ ] Have you added Release Notes in the docs repositories?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

