### PR TITLE
chore: increase java apps memory

### DIFF
--- a/acceptance-tests/helpers/apps/testapps.go
+++ b/acceptance-tests/helpers/apps/testapps.go
@@ -24,7 +24,7 @@ func (a AppCode) Dir() string {
 func WithApp(app AppCode) Option {
 	switch app {
 	case JDBCTestAppPostgres, JDBCTestAppMysql:
-		return WithOptions(WithDir(app.Dir()), WithMemory("100MB"), WithDisk("250MB"))
+		return WithOptions(WithDir(app.Dir()), WithMemory("1GB"), WithDisk("250MB"))
 	default:
 		return WithOptions(WithPreBuild(app.Dir()), WithMemory("100MB"), WithDisk("250MB"))
 	}


### PR DESCRIPTION
In a previous commit we reduced memory and disk for all apps. However java apps need more memory than their go counterparts. We could investigate and twik the JVM to use more memory but for now we will just give the apps more memory and see if that still keeps our pipelines green.

[#185528524](https://www.pivotaltracker.com/story/show/185528524)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

