### PR TITLE
fix: [ALL] fix instance_name constraints

### DIFF
--- a/aws-aurora-mysql.yml
+++ b/aws-aurora-mysql.yml
@@ -17,9 +17,9 @@ provision:
     details: Name for the DB cluster
     default: csb-auroramysql-${request.instance_id}
     constraints:
-      maxLength: 98
-      minLength: 6
-      pattern: ^[a-z][a-z0-9-]+$
+      maxLength: 63
+      minLength: 1
+      pattern: ^[a-zA-Z](-?[a-zA-Z0-9])*$
     prohibit_update: true
   - field_name: cluster_instances
     type: integer

--- a/aws-aurora-postgresql.yml
+++ b/aws-aurora-postgresql.yml
@@ -24,9 +24,9 @@ provision:
     details: Name for the DB cluster
     default: csb-aurorapg-${request.instance_id}
     constraints:
-      maxLength: 98
-      minLength: 6
-      pattern: ^[a-z][a-z0-9-]+$
+      maxLength: 63
+      minLength: 1
+      pattern: ^[a-zA-Z](-?[a-zA-Z0-9])*$
     prohibit_update: true
   - field_name: cluster_instances
     type: integer

--- a/aws-dynamodb-table.yml
+++ b/aws-dynamodb-table.yml
@@ -48,9 +48,9 @@ provision:
     details: Name of the DynamoDB table
     default: csb-dynamodb-${request.instance_id}
     constraints:
-      maxLength: 255
-      minLength: 3
-      pattern: ^[a-zA-Z0-9_-.]+$
+      maxLength: 98
+      minLength: 6
+      pattern: ^[a-z][a-z0-9-]+$
     prohibit_update: true
   - field_name: hash_key
     type: string

--- a/aws-dynamodb-table.yml
+++ b/aws-dynamodb-table.yml
@@ -48,9 +48,9 @@ provision:
     details: Name of the DynamoDB table
     default: csb-dynamodb-${request.instance_id}
     constraints:
-      maxLength: 98
-      minLength: 6
-      pattern: ^[a-z][a-z0-9-]+$
+      maxLength: 255
+      minLength: 3
+      pattern: ^[a-zA-Z0-9_-.]+$
     prohibit_update: true
   - field_name: hash_key
     type: string

--- a/aws-mssql.yml
+++ b/aws-mssql.yml
@@ -49,9 +49,9 @@ provision:
     details: Name for your MSSQL instance
     default: csb-mssql-${request.instance_id}
     constraints:
-      maxLength: 98
-      minLength: 6
-      pattern: ^[a-z][a-z0-9-]+$
+      maxLength: 63
+      minLength: 1
+      pattern: ^[a-zA-Z](-?[a-zA-Z0-9])*$
     prohibit_update: true
   - field_name: region
     type: string

--- a/aws-mysql.yml
+++ b/aws-mysql.yml
@@ -99,9 +99,9 @@ provision:
     details: Name for your mysql instance
     default: csb-mysql-${request.instance_id}
     constraints:
-      maxLength: 98
-      minLength: 6
-      pattern: ^[a-z][a-z0-9-]+$
+      maxLength: 63
+      minLength: 1
+      pattern: ^[a-zA-Z](-?[a-zA-Z0-9])*$
     prohibit_update: true
   - field_name: db_name
     type: string

--- a/aws-postgresql.yml
+++ b/aws-postgresql.yml
@@ -102,9 +102,9 @@ provision:
     details: Name for your PostgreSQL instance
     default: csb-postgresql-${request.instance_id}
     constraints:
-      maxLength: 98
-      minLength: 6
-      pattern: ^[a-z][a-z0-9-]+$
+      maxLength: 63
+      minLength: 1
+      pattern: ^[a-zA-Z](-?[a-zA-Z0-9])*$
     prohibit_update: true
   - field_name: db_name
     type: string

--- a/aws-redis.yml
+++ b/aws-redis.yml
@@ -43,8 +43,8 @@ provision:
     default: csb${request.instance_id}
     constraints:
       maxLength: 40
-      minLength: 6
-      pattern: ^[a-z][a-z0-9-]+$
+      minLength: 1
+      pattern: ^[a-zA-Z](-?[a-zA-Z0-9])*$
     prohibit_update: true
   - field_name: region
     type: string

--- a/integration-tests/aurora_mysql_test.go
+++ b/integration-tests/aurora_mysql_test.go
@@ -80,16 +80,6 @@ var _ = Describe("Aurora MySQL", Label("aurora-mysql"), func() {
 				"region: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
-				"instance name minimum length is 6 characters",
-				map[string]any{"instance_name": stringOfLen(5)},
-				"instance_name: String length must be greater than or equal to 6",
-			),
-			Entry(
-				"instance name maximum length is 98 characters",
-				map[string]any{"instance_name": stringOfLen(99)},
-				"instance_name: String length must be less than or equal to 98",
-			),
-			Entry(
 				"instance name invalid characters",
 				map[string]any{"instance_name": ".aaaaa"},
 				"instance_name: Does not match pattern '^[a-z][a-z0-9-]+$'",

--- a/integration-tests/aurora_mysql_test.go
+++ b/integration-tests/aurora_mysql_test.go
@@ -80,9 +80,28 @@ var _ = Describe("Aurora MySQL", Label("aurora-mysql"), func() {
 				"region: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
-				"instance name invalid characters",
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-cluster.html#options
+				"instance name will be used as db-cluster-identifier so must contain from 1 to 63 letters, numbers or hyphens",
+				map[string]any{"instance_name": stringOfLen(64)},
+				"instance_name: String length must be less than or equal to 63",
+			),
+			Entry(
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-cluster.html#options
+				"instance name will be used as db-cluster-identifier so the first character must be a letter",
 				map[string]any{"instance_name": ".aaaaa"},
-				"instance_name: Does not match pattern '^[a-z][a-z0-9-]+$'",
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
+			),
+			Entry(
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-cluster.html#options
+				"instance name will be used as db-cluster-identifier so it cannot end with a hyphen",
+				map[string]any{"instance_name": "aaaaa-"},
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
+			),
+			Entry(
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-cluster.html#options
+				"instance name will be used as db-cluster-identifier so it cannot contain two consecutive hyphens",
+				map[string]any{"instance_name": "aa--aaa"},
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
 			),
 			Entry(
 				"database name maximum length is 64 characters",

--- a/integration-tests/aurora_postgresql_test.go
+++ b/integration-tests/aurora_postgresql_test.go
@@ -78,9 +78,28 @@ var _ = Describe("Aurora PostgreSQL", Label("aurora-postgresql"), func() {
 				"region: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
-				"instance name invalid characters",
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-cluster.html#options
+				"instance name will be used as db-cluster-identifier so must contain from 1 to 63 letters, numbers or hyphens",
+				map[string]any{"instance_name": stringOfLen(64)},
+				"instance_name: String length must be less than or equal to 63",
+			),
+			Entry(
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-cluster.html#options
+				"instance name will be used as db-cluster-identifier so the first character must be a letter",
 				map[string]any{"instance_name": ".aaaaa"},
-				"instance_name: Does not match pattern '^[a-z][a-z0-9-]+$'",
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
+			),
+			Entry(
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-cluster.html#options
+				"instance name will be used as db-cluster-identifier so it cannot end with a hyphen",
+				map[string]any{"instance_name": "aaaaa-"},
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
+			),
+			Entry(
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-cluster.html#options
+				"instance name will be used as db-cluster-identifier so it cannot contain two consecutive hyphens",
+				map[string]any{"instance_name": "aa--aaa"},
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
 			),
 			Entry(
 				"database name maximum length is 64 characters",

--- a/integration-tests/aurora_postgresql_test.go
+++ b/integration-tests/aurora_postgresql_test.go
@@ -78,16 +78,6 @@ var _ = Describe("Aurora PostgreSQL", Label("aurora-postgresql"), func() {
 				"region: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
-				"instance name minimum length is 6 characters",
-				map[string]any{"instance_name": stringOfLen(5)},
-				"instance_name: String length must be greater than or equal to 6",
-			),
-			Entry(
-				"instance name maximum length is 98 characters",
-				map[string]any{"instance_name": stringOfLen(99)},
-				"instance_name: String length must be less than or equal to 98",
-			),
-			Entry(
 				"instance name invalid characters",
 				map[string]any{"instance_name": ".aaaaa"},
 				"instance_name: Does not match pattern '^[a-z][a-z0-9-]+$'",

--- a/integration-tests/mssql_test.go
+++ b/integration-tests/mssql_test.go
@@ -113,16 +113,6 @@ var _ = Describe("MSSQL", Label("MSSQL"), func() {
 				"region: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
-				"instance name minimum length is 6 characters",
-				map[string]any{"instance_name": stringOfLen(5)},
-				"instance_name: String length must be greater than or equal to 6",
-			),
-			Entry(
-				"instance name maximum length is 98 characters",
-				map[string]any{"instance_name": stringOfLen(99)},
-				"instance_name: String length must be less than or equal to 98",
-			),
-			Entry(
 				"instance name invalid characters",
 				map[string]any{"instance_name": ".aaaaa"},
 				"instance_name: Does not match pattern '^[a-z][a-z0-9-]+$'",

--- a/integration-tests/mssql_test.go
+++ b/integration-tests/mssql_test.go
@@ -113,9 +113,28 @@ var _ = Describe("MSSQL", Label("MSSQL"), func() {
 				"region: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
-				"instance name invalid characters",
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html#options
+				"instance name will be used as db-instance-identifier so must contain from 1 to 63 letters, numbers or hyphens",
+				map[string]any{"instance_name": stringOfLen(64)},
+				"instance_name: String length must be less than or equal to 63",
+			),
+			Entry(
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html#options
+				"instance name will be used as db-instance-identifier so the first character must be a letter",
 				map[string]any{"instance_name": ".aaaaa"},
-				"instance_name: Does not match pattern '^[a-z][a-z0-9-]+$'",
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
+			),
+			Entry(
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html#options
+				"instance name will be used as db-instance-identifier so it cannot end with a hyphen",
+				map[string]any{"instance_name": "aaaaa-"},
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
+			),
+			Entry(
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html#options
+				"instance name will be used as db-instance-identifier so it cannot contain two consecutive hyphens",
+				map[string]any{"instance_name": "aa--aaa"},
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
 			),
 			Entry(
 				"database name maximum length is 64 characters",

--- a/integration-tests/mysql_test.go
+++ b/integration-tests/mysql_test.go
@@ -81,16 +81,6 @@ var _ = Describe("MySQL", Label("MySQL"), func() {
 				"region: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
-				"instance name minimum length is 6 characters",
-				map[string]any{"instance_name": stringOfLen(5)},
-				"instance_name: String length must be greater than or equal to 6",
-			),
-			Entry(
-				"instance name maximum length is 98 characters",
-				map[string]any{"instance_name": stringOfLen(99)},
-				"instance_name: String length must be less than or equal to 98",
-			),
-			Entry(
 				"instance name invalid characters",
 				map[string]any{"instance_name": ".aaaaa"},
 				"instance_name: Does not match pattern '^[a-z][a-z0-9-]+$'",

--- a/integration-tests/mysql_test.go
+++ b/integration-tests/mysql_test.go
@@ -81,9 +81,28 @@ var _ = Describe("MySQL", Label("MySQL"), func() {
 				"region: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
-				"instance name invalid characters",
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html#options
+				"instance name will be used as db-instance-identifier so must contain from 1 to 63 letters, numbers or hyphens",
+				map[string]any{"instance_name": stringOfLen(64)},
+				"instance_name: String length must be less than or equal to 63",
+			),
+			Entry(
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html#options
+				"instance name will be used as db-instance-identifier so the first character must be a letter",
 				map[string]any{"instance_name": ".aaaaa"},
-				"instance_name: Does not match pattern '^[a-z][a-z0-9-]+$'",
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
+			),
+			Entry(
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html#options
+				"instance name will be used as db-instance-identifier so it cannot end with a hyphen",
+				map[string]any{"instance_name": "aaaaa-"},
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
+			),
+			Entry(
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html#options
+				"instance name will be used as db-instance-identifier so it cannot contain two consecutive hyphens",
+				map[string]any{"instance_name": "aa--aaa"},
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
 			),
 			Entry(
 				"database name maximum length is 64 characters",

--- a/integration-tests/postgresql_test.go
+++ b/integration-tests/postgresql_test.go
@@ -81,19 +81,9 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 				"region: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
-				"instance name minimum length is 6 characters",
-				map[string]any{"instance_name": stringOfLen(5)},
-				"instance_name: String length must be greater than or equal to 6",
-			),
-			Entry(
 				"instance name invalid characters",
 				map[string]any{"instance_name": ".aaaaa"},
 				"instance_name: Does not match pattern '^[a-z][a-z0-9-]+$'",
-			),
-			Entry(
-				"database name maximum length is 98 characters",
-				map[string]any{"db_name": stringOfLen(99)},
-				"db_name: String length must be less than or equal to 64",
 			),
 			Entry(
 				"performance_insights_retention_period minimum value is 7",

--- a/integration-tests/postgresql_test.go
+++ b/integration-tests/postgresql_test.go
@@ -81,9 +81,28 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 				"region: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
-				"instance name invalid characters",
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html#options
+				"instance name will be used as db-instance-identifier so must contain from 1 to 63 letters, numbers or hyphens",
+				map[string]any{"instance_name": stringOfLen(64)},
+				"instance_name: String length must be less than or equal to 63",
+			),
+			Entry(
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html#options
+				"instance name will be used as db-instance-identifier so the first character must be a letter",
 				map[string]any{"instance_name": ".aaaaa"},
-				"instance_name: Does not match pattern '^[a-z][a-z0-9-]+$'",
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
+			),
+			Entry(
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html#options
+				"instance name will be used as db-instance-identifier so it cannot end with a hyphen",
+				map[string]any{"instance_name": "aaaaa-"},
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
+			),
+			Entry(
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html#options
+				"instance name will be used as db-instance-identifier so it cannot contain two consecutive hyphens",
+				map[string]any{"instance_name": "aa--aaa"},
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
 			),
 			Entry(
 				"performance_insights_retention_period minimum value is 7",

--- a/integration-tests/redis_test.go
+++ b/integration-tests/redis_test.go
@@ -114,14 +114,28 @@ var _ = Describe("Redis", Label("Redis"), func() {
 				"region: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
-				"instance name maximum length is 40 characters",
+				// https://docs.aws.amazon.com/cli/latest/reference/elasticache/create-replication-group.html#options
+				"instance name will be used as replication-group-id so must contain from 1 to 40 alphanumeric characters or hyphens",
 				map[string]any{"instance_name": stringOfLen(41)},
 				"instance_name: String length must be less than or equal to 40",
 			),
 			Entry(
-				"instance name invalid characters",
+				// https://docs.aws.amazon.com/cli/latest/reference/elasticache/create-replication-group.html#options
+				"instance name will be used as replication-group-id so the first character must be a letter",
 				map[string]any{"instance_name": ".aaaaa"},
-				"instance_name: Does not match pattern '^[a-z][a-z0-9-]+$'",
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
+			),
+			Entry(
+				// https://docs.aws.amazon.com/cli/latest/reference/elasticache/create-replication-group.html#options
+				"instance name will be used as replication-group-id so it cannot end with a hyphen",
+				map[string]any{"instance_name": "aaaaa-"},
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
+			),
+			Entry(
+				// https://docs.aws.amazon.com/cli/latest/reference/elasticache/create-replication-group.html#options
+				"instance name will be used as replication-group-id so it cannot contain two consecutive hyphens",
+				map[string]any{"instance_name": "aa--aaa"},
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
 			),
 			Entry(
 				"maintenance_day invalid day",

--- a/integration-tests/redis_test.go
+++ b/integration-tests/redis_test.go
@@ -114,11 +114,6 @@ var _ = Describe("Redis", Label("Redis"), func() {
 				"region: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
-				"instance name minimum length is 6 characters",
-				map[string]any{"instance_name": stringOfLen(5)},
-				"instance_name: String length must be greater than or equal to 6",
-			),
-			Entry(
 				"instance name maximum length is 40 characters",
 				map[string]any{"instance_name": stringOfLen(41)},
 				"instance_name: String length must be less than or equal to 40",

--- a/terraform/aurora-mysql/provision/main.tf
+++ b/terraform/aurora-mysql/provision/main.tf
@@ -90,6 +90,12 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
 
   lifecycle {
     prevent_destroy = true
+
+    # See https://github.com/cloudfoundry/csb-brokerpak-aws/pull/1042#issuecomment-1660452452 for a justification for this precondition
+    precondition {
+      condition     = length("${var.instance_name}-${var.cluster_instances - 1}") <= 63
+      error_message = "Some cluster instances would have names longer than 63 characters. Please provide a shorter instance_name."
+    }
   }
 }
 

--- a/terraform/aurora-postgresql/provision/main.tf
+++ b/terraform/aurora-postgresql/provision/main.tf
@@ -89,6 +89,12 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
 
   lifecycle {
     prevent_destroy = true
+
+    # See https://github.com/cloudfoundry/csb-brokerpak-aws/pull/1042#issuecomment-1660452452 for a justification for this precondition
+    precondition {
+      condition     = length("${var.instance_name}-${var.cluster_instances - 1}") <= 63
+      error_message = "Some cluster instances would have names longer than 63 characters. Please provide a shorter instance_name."
+    }
   }
 }
 
@@ -97,6 +103,9 @@ resource "aws_rds_cluster_parameter_group" "cluster_parameter_group" {
   family = format("aurora-postgresql%s", local.major_version)
   # Must not match the name of an existing DB cluster parameter group.
   # See https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBClusterParameterGroup.html
+  # Undocumented max length is 255
+  # Undocumented constraint:
+  # must begin with a letter; must contain only ASCII letters, digits, and hyphens; and must not end with a hyphen or contain two consecutive hyphens.
   name_prefix = format("aurora-pg-%s", var.instance_name)
 
   parameter {


### PR DESCRIPTION
[#185758370]

It seems we have been copy-pasting some of these constraints without checking whether they were correct, wrong, outdated...

Current constraints according to the AWS Web Console are:
- Must be 63 characters or less.
- Must start with a letter (A-Z and a-z)
- Must contain only letters, numbers and hyphens.
- Must not have two consecutive hyphens
- Must not have a hyphen at the end.

I took the occasion to review other services apart from AWS MSSQL and fix their instance_name constraints too.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

