### PR TITLE
fix: [MSSQL] fix instance_name constraints

### DIFF
--- a/aws-mssql.yml
+++ b/aws-mssql.yml
@@ -49,9 +49,9 @@ provision:
     details: Name for your MSSQL instance
     default: csb-mssql-${request.instance_id}
     constraints:
-      maxLength: 98
-      minLength: 6
-      pattern: ^[a-z][a-z0-9-]+$
+      maxLength: 63
+      minLength: 1
+      pattern: ^[a-zA-Z](-?[a-zA-Z0-9])*$
     prohibit_update: true
   - field_name: region
     type: string

--- a/integration-tests/mssql_test.go
+++ b/integration-tests/mssql_test.go
@@ -113,19 +113,28 @@ var _ = Describe("MSSQL", Label("MSSQL"), func() {
 				"region: Does not match pattern '^[a-z][a-z0-9-]+$'",
 			),
 			Entry(
-				"instance name minimum length is 6 characters",
-				map[string]any{"instance_name": stringOfLen(5)},
-				"instance_name: String length must be greater than or equal to 6",
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html#options
+				"instance name will be used as db-instance-identifier so must contain from 1 to 63 letters, numbers or hyphens",
+				map[string]any{"instance_name": stringOfLen(64)},
+				"instance_name: String length must be less than or equal to 63",
 			),
 			Entry(
-				"instance name maximum length is 98 characters",
-				map[string]any{"instance_name": stringOfLen(99)},
-				"instance_name: String length must be less than or equal to 98",
-			),
-			Entry(
-				"instance name invalid characters",
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html#options
+				"instance name will be used as db-instance-identifier so the first character must be a letter",
 				map[string]any{"instance_name": ".aaaaa"},
-				"instance_name: Does not match pattern '^[a-z][a-z0-9-]+$'",
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
+			),
+			Entry(
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html#options
+				"instance name will be used as db-instance-identifier so it cannot end with a hyphen",
+				map[string]any{"instance_name": "aaaaa-"},
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
+			),
+			Entry(
+				// https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html#options
+				"instance name will be used as db-instance-identifier so it cannot contain two consecutive hyphens",
+				map[string]any{"instance_name": "aa--aaa"},
+				"instance_name: Does not match pattern '^[a-zA-Z](-?[a-zA-Z0-9])*$'",
 			),
 			Entry(
 				"database name maximum length is 64 characters",


### PR DESCRIPTION
[#185286271]

Current constraints according to the AWS Web Console are:
- Must be 63 characters or less.
- Must start with a letter (A-Z and a-z)
- Must contain only letters, numbers and hyphens.
- Must not have two consecutive hyphens
- Must not have a hyphen at the end.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

