### PR TITLE
fix: [MSSQL] with defaults kms_key_id is null

### DIFF
--- a/terraform-tests/mssql_test.go
+++ b/terraform-tests/mssql_test.go
@@ -71,7 +71,6 @@ var _ = Describe("mssql", Label("mssql-terraform"), Ordered, func() {
 				"engine_version":       Equal("some-engine-version"),
 				"identifier":           Equal("csb-mssql-test"),
 				"storage_encrypted":    BeTrue(),
-				"kms_key_id":           Equal(""),
 				"instance_class":       Equal(""),
 				"tags":                 HaveKeyWithValue("label1", "value1"),
 				"db_subnet_group_name": Equal("csb-mssql-test-p-sn"),


### PR DESCRIPTION
[#185149632]

When no kms_key_id is provided or an empty string is provided   no value for kms_key_id is sent to terraform. Test was wrong.

### Checklist:

* ~~[ ] Have you added Release Notes in the docs repositories?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

