### PR TITLE
feat: [MSSQL] expose support for storage autoscale

### DIFF
--- a/aws-mssql.yml
+++ b/aws-mssql.yml
@@ -37,6 +37,13 @@ provision:
     constraints:
       minimum: 20
       maximum: 16384
+  - field_name: max_allocated_storage
+    type: integer
+    nullable: true
+    default: 0
+    details: |
+      Upper limit to which Amazon RDS can automatically scale the storage of the DB instance.
+      Must be greater than or equal to `storage_gb` or 0 to disable Storage Autoscaling.
   - field_name: storage_encrypted
     type: boolean
     default: true

--- a/terraform-tests/mssql_test.go
+++ b/terraform-tests/mssql_test.go
@@ -27,6 +27,7 @@ var _ = Describe("mssql", Label("mssql-terraform"), Ordered, func() {
 		"kms_key_id":            "",
 		"db_name":               "vsbdb",
 		"labels":                map[string]string{"label1": "value1"},
+		"max_allocated_storage": 0,
 
 		"aws_vpc_id":                 "",
 		"rds_subnet_group":           "",
@@ -148,6 +149,15 @@ var _ = Describe("mssql", Label("mssql-terraform"), Ordered, func() {
 			It("should use the passed value", func() {
 				plan = ShowPlan(terraformProvisionDir, buildVars(defaultVars, requiredVars, map[string]any{"storage_gb": 60}))
 				Expect(AfterValuesForType(plan, "aws_db_instance")).To(MatchKeys(IgnoreExtras, Keys{"allocated_storage": Equal(float64(60))}))
+			})
+		})
+	})
+
+	Context("max_allocated_storage", func() {
+		When("valid max_allocated_storage passed", func() {
+			It("should use the passed value", func() {
+				plan = ShowPlan(terraformProvisionDir, buildVars(defaultVars, requiredVars, map[string]any{"max_allocated_storage": 250}))
+				Expect(AfterValuesForType(plan, "aws_db_instance")).To(MatchKeys(IgnoreExtras, Keys{"max_allocated_storage": Equal(float64(250))}))
 			})
 		})
 	})

--- a/terraform/mssql/provision/main.tf
+++ b/terraform/mssql/provision/main.tf
@@ -36,6 +36,7 @@ resource "random_password" "password" {
 resource "aws_db_instance" "db_instance" {
   license_model          = "license-included"
   allocated_storage      = var.storage_gb
+  max_allocated_storage  = var.max_allocated_storage
   engine                 = var.engine
   engine_version         = var.mssql_version
   instance_class         = var.instance_class

--- a/terraform/mssql/provision/variables.tf
+++ b/terraform/mssql/provision/variables.tf
@@ -13,3 +13,7 @@ variable "rds_vpc_security_group_ids" { type = string }
 variable "mssql_version" { type = string }
 variable "engine" { type = string }
 variable "storage_gb" { type = number }
+variable "max_allocated_storage" {
+  type     = number
+  nullable = true
+}


### PR DESCRIPTION
[#185149499]

This implementation doesn't follow conventions stablished in mysql or postgresql on how to expose storage autoscale.

A larger discussion of the reasons can be found in the tracker story. The summary is we no longer need to.

We can now define nullable numbers which were impossible before we can also use Terraform preconditions to validate inputs, etc

### Checklist:

* [x] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

