### PR TITLE
fix: [MSSQL] entries without prohibit_update also failed

### DIFF
--- a/integration-tests/mssql_test.go
+++ b/integration-tests/mssql_test.go
@@ -196,7 +196,7 @@ var _ = Describe("MSSQL", Label("MSSQL"), func() {
 
 		DescribeTable("should prevent updating properties flagged as `prohibit_update` because it can result in the recreation of the service instance",
 			func(prop string, value any) {
-				err := broker.Update(instanceID, msSQLServiceName, customMSSQLPlan["name"].(string), buildProperties(defaultProperties(), requiredProperties(), map[string]any{prop: value}))
+				err := broker.Update(instanceID, msSQLServiceName, customMSSQLPlan["name"].(string), map[string]any{prop: value})
 
 				Expect(err).To(MatchError(
 					ContainSubstring(


### PR DESCRIPTION
[#185149499]

We were passing default and required fields to the update operation and some of these fields have prohibit update so every entry was failing but not necessarily for the right reason.

### Checklist:

* ~~[ ] Have you added Release Notes in the docs repositories?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

