### PR TITLE
fix: [MSSQL] eliminate the default and go for nullable

### DIFF
--- a/aws-mssql.yml
+++ b/aws-mssql.yml
@@ -40,10 +40,9 @@ provision:
   - field_name: max_allocated_storage
     type: integer
     nullable: true
-    default: 0
     details: |
       Upper limit to which Amazon RDS can automatically scale the storage of the DB instance.
-      Must be greater than or equal to `storage_gb` or 0 to disable Storage Autoscaling.
+      Must be greater than or equal to `storage_gb`. Set it to null or 0 to disable Storage Autoscaling.
   - field_name: storage_encrypted
     type: boolean
     default: true


### PR DESCRIPTION
[#185149499]

- We made the field nullable yet the default is 0 and docs say we need to set to 0 to disable. This means it doesn't need to be nullable.
- In previous discussions around this kind of interface, the team agreed that a 0 value, although in use by the provider and probably by the API, it is not as intuitive as null, hence preferred way to implement would be to set to null by default and instruct the user to set to null to disable, whilst treating null as 0 when passing it to terraform.

### Checklist:

* [x] Have you added Release Notes in the docs repositories?
* [x] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

