### PR TITLE
chore: add make target to run only modified tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,10 @@ run-integration-tests: run-provider-tests ## run integration tests for this brok
 run-terraform-tests: providers custom.tfrc ## run terraform tests for this brokerpak
 	cd ./terraform-tests && TF_CLI_CONFIG_FILE="$(PWD)/custom.tfrc" go run github.com/onsi/ginkgo/v2/ginkgo -r .
 
+.PHONY: run-modified-tests
+run-modified-tests: providers custom.tfrc
+	TF_CLI_CONFIG_FILE="$(PWD)/custom.tfrc" go run github.com/onsi/ginkgo/v2/ginkgo -r --timeout=3h --focus-file none $$(git diff --name-only HEAD | awk '{printf(" --focus-file  %s", $$0)}')
+
 .PHONY: run-provider-tests
 run-provider-tests:  ## run the integration tests associated with providers
 	cd providers/terraform-provider-csbdynamodbns; $(MAKE) test


### PR DESCRIPTION
Existing targets run all terraform or integrations tests for all services unless you use FIt, FDescribe, FWhen, etc to limit them.

This new Makefile uses git to detect which files were modified and pass them to ginkgo through the `--focus-file`. This in effect causes Ginkgo to ignore any other tests files in the project.

Warning: This target doesn't try to be smart and automatically run any tests related to some modified non-test file. The only thing this target does is run any test files modified in the current branch.

### Checklist:

* ~~[ ] Have you added Release Notes in the docs repositories?~~
* ~~[ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?~~
* ~~[ ] Have you ran acceptance tests for the service under change?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

