### PR TITLE
fix: engine should not be updateable

### DIFF
--- a/aws-mssql.yml
+++ b/aws-mssql.yml
@@ -22,6 +22,7 @@ provision:
       sqlserver-ex: sqlserver-ex
       sqlserver-se: sqlserver-se
       sqlserver-web: sqlserver-web
+    prohibit_update: true
   - field_name: mssql_version
     required: true
     type: string


### PR DESCRIPTION
The engine modification causes the recreation of the instance.

[#186142807](https://www.pivotaltracker.com/story/show/186142807)

### Checklist:

* [x] Have you added Release Notes in the docs repositories?
* [x] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* ~~[ ] Have you ran acceptance tests for the service under change?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

