### PR TITLE
fix: [MSSQL] make tests detect unbinding issue

### DIFF
--- a/acceptance-tests/mssql_data_migration_test.go
+++ b/acceptance-tests/mssql_data_migration_test.go
@@ -60,7 +60,7 @@ var _ = Describe("MSSQL data migration", Label("mssql-migration"), func() {
 		apps.Start(golangAppOne)
 		By("creating a schema using the app")
 		schema := random.Name(random.WithMaxLength(10))
-		golangAppOne.PUT("", "%s?tls=disable", schema)
+		golangAppOne.PUT("", "%s?dbo=false&tls=disable", schema)
 
 		By("setting a key-value using the app")
 		key := random.Hexadecimal()

--- a/acceptance-tests/mssql_test.go
+++ b/acceptance-tests/mssql_test.go
@@ -69,7 +69,7 @@ var _ = Describe("MSSQL", Label("mssql"), func() {
 		apps.Start(golangAppOne, golangAppTwo)
 		By("creating a schema using the first app")
 		schema := random.Name(random.WithMaxLength(10))
-		golangAppOne.PUT("", schema)
+		golangAppOne.PUT("", "%s?dbo=false", schema)
 
 		By("setting a key-value using the first app")
 		key := random.Hexadecimal()

--- a/providers/terraform-provider-csbsqlserver/connector/connector_test.go
+++ b/providers/terraform-provider-csbsqlserver/connector/connector_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Connector", func() {
 
 			By("checking that it can connect and create data")
 			udb := testhelpers.Connect(bindingUsername, bindingPassword, testhelpers.TestDatabase, port)
-			_, err = udb.Exec(`CREATE SCHEMA test AUTHORIZATION dbo`)
+			_, err = udb.Exec(`CREATE SCHEMA test`)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -104,6 +104,35 @@ var _ = Describe("Connector", func() {
 			defer rows.Close()
 			Expect(rows.Next()).To(BeFalse(), "login still exists")
 		})
+
+		It("reassigns ownership on deletion", func() {
+			bindingUsername := uuid.NewString()
+			bindingPassword := testhelpers.RandomPassword()
+
+			By("creating the binding")
+			err := conn.CreateBinding(context.TODO(), bindingUsername, bindingPassword, []string{"db_owner"})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking that the binding user exists")
+			Expect(testhelpers.UserExists(db, bindingUsername)).To(BeTrue())
+
+			By("connecting and creating data")
+			value := uuid.NewString()
+			udb := testhelpers.Connect(bindingUsername, bindingPassword, testhelpers.TestDatabase, port)
+			_, err = udb.Exec(`CREATE SCHEMA reassignment`)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = db.Exec(`CREATE TABLE reassignment.test (keyname VARCHAR(255) NOT NULL, valuename VARCHAR(max) NOT NULL)`)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = db.Exec(`INSERT INTO reassignment.test (keyname, valuename) VALUES ('saved', @p1)`, value)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("deleting the binding")
+			err = conn.DeleteBinding(context.TODO(), bindingUsername)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking that the binding user does not exist")
+			Expect(testhelpers.UserExists(db, bindingUsername)).To(BeFalse(), "binding user still exists")
+		})
 	})
 
 	Describe("ReadBinding()", func() {
@@ -139,7 +168,7 @@ var _ = Describe("Connector", func() {
 			By("connecting and creating data")
 			value := uuid.NewString()
 			udb := testhelpers.Connect(bindingUsername1, bindingPassword1, testhelpers.TestDatabase, port)
-			_, err = udb.Exec(`CREATE SCHEMA persist AUTHORIZATION dbo`)
+			_, err = udb.Exec(`CREATE SCHEMA persist`)
 			Expect(err).NotTo(HaveOccurred())
 			_, err = db.Exec(`CREATE TABLE persist.test (keyname VARCHAR(255) NOT NULL, valuename VARCHAR(max) NOT NULL)`)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
[#185100152](https://www.pivotaltracker.com/story/show/185100152)

Mssql's example app created SCHEMAs passing AUTHORIZATION dbo This caused the schema to be assigned to dbo at creation time causing the unbinding issue to pass unnoticed

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [x] Have you ran acceptance tests for the service under change?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

