### PR TITLE
chore: backporting query change for mssql provider to keep alignment

### DIFF
--- a/providers/terraform-provider-csbsqlserver/connector/connector.go
+++ b/providers/terraform-provider-csbsqlserver/connector/connector.go
@@ -109,7 +109,7 @@ func (c *Connector) ReadBinding(ctx context.Context, username string) (result bo
 
 func (c *Connector) CheckDatabaseExists(ctx context.Context, dbName string) (result bool, err error) {
 	return result, c.withDefaultDBConnection(func(db *sql.DB) (err error) {
-		statement := `SELECT 1 FROM master.dbo.sysdatabases where name=@p1`
+		statement := `SELECT 1 FROM sys.databases where name=@p1`
 		rows, err := db.QueryContext(ctx, statement, dbName)
 		if err != nil {
 			return fmt.Errorf("error querying existence of database %q: %w", dbName, err)

--- a/providers/terraform-provider-csbsqlserver/csbsqlserver/binding_resource_test.go
+++ b/providers/terraform-provider-csbsqlserver/csbsqlserver/binding_resource_test.go
@@ -232,7 +232,7 @@ func testCheckUserDoesNotExists(db *sql.DB, username string) func(state *terrafo
 
 func testCheckDatabaseExists(db *sql.DB, databaseName string) func(state *terraform.State) error {
 	return func(state *terraform.State) error {
-		statement := `SELECT 1 FROM master.dbo.sysdatabases where name=@p1`
+		statement := `SELECT 1 FROM sys.databases where name=@p1`
 		rows, err := db.Query(statement, databaseName)
 		if err != nil {
 			return fmt.Errorf("error querying existence of database %q: %w", databaseName, err)


### PR DESCRIPTION
with azure provider

- master.dbo.sysdatabases in not accessible in azure. However the system view sys.databases is and also works fine in AWS. So opting to use that system view to decide if the database already exists.

[#185100152](https://www.pivotaltracker.com/story/show/185100152)

### Checklist:

~~* [ ] Have you added Release Notes in the docs repositories?~~
* [X] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

