### PR TITLE
feat: implement dynamodb without creation IAM users

### DIFF
--- a/acceptance-tests/apps/dynamodbtableapp/internal/credentials/credentials.go
+++ b/acceptance-tests/apps/dynamodbtableapp/internal/credentials/credentials.go
@@ -10,8 +10,15 @@ import (
 type DynamoDBService struct {
 	AccessKeyId     string `mapstructure:"access_key_id"`
 	AccessKeySecret string `mapstructure:"secret_access_key"`
+	CredsEndpoint   string `mapstructure:"creds_endpoint"`
+	RoleName        string `mapstructure:"role_name"`
 	Region          string `mapstructure:"region"`
 	TableName       string `mapstructure:"dynamodb_table_name"`
+}
+
+type Creds struct {
+	AccessKeyId     string `json:"AccessKeyId"`
+	SecretAccessKey string `json:"SecretAccessKey"`
 }
 
 func Read() (DynamoDBService, error) {

--- a/acceptance-tests/dynamodb_table_test.go
+++ b/acceptance-tests/dynamodb_table_test.go
@@ -73,5 +73,9 @@ func config() any {
 				"non_key_attributes": []string{"id"},
 			},
 		},
+		"iam_arn":        "arn:aws:iam::000000000000:user/this-user-must-exist-and-have-permission-to-assume-role",
+		"role_name":      "this-role-must-exist-and-allow-the-above-user-to-assume-role",
+		"region":         "us-west-1",
+		"creds_endpoint": "https://the-endpoint-for-the-cloud-service-broker.csb.cf-app.com/creds",
 	}
 }

--- a/aws-dynamodb-table.yml
+++ b/aws-dynamodb-table.yml
@@ -131,6 +131,24 @@ provision:
     type: string
     details: VPC ID for instance
     default: ""
+  - field_name: iam_arn
+    type: string
+    prohibit_update: true
+    required: true
+    default: ""
+    details: An existing IAM user with permission to 'assumerole' the specified `role_name`.
+  - field_name: role_name
+    type: string
+    prohibit_update: true
+    default: ""
+    details: |
+      If an existing role is passed, a new policy condition will be added to it.
+      If empty, a new role for each binding will be created.
+  - field_name: creds_endpoint
+    type: string
+    required: true
+    prohibit_update: true
+    details: The endpoint for fetching the binding creds
   computed_inputs:
   - name: labels
     default: ${json.marshal(request.default_labels)}
@@ -159,6 +177,17 @@ provision:
   - field_name: region
     type: string
     details: AWS region for the bucket
+  - field_name: iam_arn
+    type: string
+    details: An existing IAM user with permission to 'assumerole' the specified `role_name`.
+  - field_name: role_name
+    type: string
+    details: |
+      If an existing role is passed, a new policy condition will be added to it.
+      If empty, a new role for each binding will be created.
+  - field_name: creds_endpoint
+    type: string
+    details: The endpoint for fetching the binding creds
 bind:
   plan_inputs: []
   user_inputs:
@@ -183,14 +212,22 @@ bind:
     type: string
     default: ${instance.details["dynamodb_table_name"]}
     overwrite: true
-  - name: user_name
-    default: csb-${request.binding_id}
-    overwrite: true
-    type: string
   - name: region
     default: ${instance.details["region"]}
     overwrite: true
     type: string
+  - name: iam_arn
+    type: string
+    default: ${instance.details["iam_arn"]}
+    overwrite: true
+  - name: role_name
+    type: string
+    default: ${instance.details["role_name"]}
+    overwrite: true
+  - name: creds_endpoint
+    type: string
+    default: ${instance.details["creds_endpoint"]}
+    overwrite: true
   template_refs:
     data: terraform/dynamodb-table/bind/data.tf
     main: terraform/dynamodb-table/bind/main.tf
@@ -211,9 +248,15 @@ bind:
   - field_name: secret_access_key
     type: string
     details: AWS secret access key
+  - field_name: creds_endpoint
+    type: string
+    details: The endpoint for fetching the binding creds
   - field_name: region
     type: string
     details: AWS region for the bucket
+  - field_name: creds_endpoint
+    type: string
+    details: The endpoint for fetching the binding creds
 examples:
 - name: ondemand
   description: Create a dynamodb instance

--- a/terraform/dynamodb-table/bind/data.tf
+++ b/terraform/dynamodb-table/bind/data.tf
@@ -12,7 +12,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "aws_iam_policy_document" "user_policy" {
+locals {
+  binding_role = try(aws_iam_role.new_role[0], data.aws_iam_role.provided[0])
+}
+
+resource "random_password" "source_identity" {
+  length  = 16
+  special = false
+}
+
+data "aws_iam_role" "provided" {
+  count = length(var.role_name) == 0 ? 0 : 1
+
+  name = var.role_name
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    sid = "assumeRole"
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = [var.iam_arn]
+    }
+    condition {
+      test     = "StringEquals"
+      values   = [random_password.source_identity.result]
+      variable = "aws:RequestTag/current-binding"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "dynamo_access" {
   statement {
     sid = "dynamoAccess"
     actions = [
@@ -21,5 +55,10 @@ data "aws_iam_policy_document" "user_policy" {
     resources = [
       var.dynamodb_table_arn
     ]
+    condition {
+      test     = "StringEquals"
+      values   = [random_password.source_identity.result]
+      variable = "aws:PrincipalTag/current-binding"
+    }
   }
 }

--- a/terraform/dynamodb-table/bind/main.tf
+++ b/terraform/dynamodb-table/bind/main.tf
@@ -12,19 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-resource "aws_iam_user" "user" {
-  name = var.user_name
-  path = "/cf/"
+resource "aws_iam_role" "new_role" {
+  count = length(var.role_name) == 0 ? 1 : 0
+
+  path               = "/cf/"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
-resource "aws_iam_access_key" "access_key" {
-  user = aws_iam_user.user.name
+resource "aws_iam_role_policy" "add_allow_dynamodb_policy" {
+  role   = local.binding_role.name
+  policy = data.aws_iam_policy_document.dynamo_access.json
 }
 
-resource "aws_iam_user_policy" "user_policy" {
-  name = format("%s-p", var.user_name)
-
-  user = aws_iam_user.user.name
-
-  policy = data.aws_iam_policy_document.user_policy.json
-}

--- a/terraform/dynamodb-table/bind/outputs.tf
+++ b/terraform/dynamodb-table/bind/outputs.tf
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 output "access_key_id" {
-  value     = aws_iam_access_key.access_key.id
+  value     = local.binding_role.arn
   sensitive = true
 }
 output "secret_access_key" {
-  value     = aws_iam_access_key.access_key.secret
+  value     = random_password.source_identity.result
   sensitive = true
 }
 output "dynamodb_table_arn" { value = var.dynamodb_table_arn }
 output "dynamodb_table_id" { value = var.dynamodb_table_arn }
 output "region" { value = var.region }
+output "creds_endpoint" { value = var.creds_endpoint }

--- a/terraform/dynamodb-table/bind/variables.tf
+++ b/terraform/dynamodb-table/bind/variables.tf
@@ -14,4 +14,6 @@
 
 variable "dynamodb_table_arn" { type = string }
 variable "dynamodb_table_id" { type = string }
-variable "user_name" { type = string }
+variable "iam_arn" { type = string }
+variable "role_name" { type = string }
+variable "creds_endpoint" { type = string }

--- a/terraform/dynamodb-table/provision/outputs.tf
+++ b/terraform/dynamodb-table/provision/outputs.tf
@@ -16,3 +16,6 @@ output "region" { value = var.region }
 output "dynamodb_table_arn" { value = element(concat(aws_dynamodb_table.this.*.arn, tolist([])), 0) }
 output "dynamodb_table_id" { value = element(concat(aws_dynamodb_table.this.*.id, tolist([])), 0) }
 output "dynamodb_table_name" { value = aws_dynamodb_table.this.name }
+output "iam_arn" { value = var.iam_arn }
+output "role_name" { value = var.role_name }
+output "creds_endpoint" { value = var.creds_endpoint }

--- a/terraform/dynamodb-table/provision/variables.tf
+++ b/terraform/dynamodb-table/provision/variables.tf
@@ -34,3 +34,6 @@ variable "server_side_encryption_enabled" { type = bool }
 
 variable "write_capacity" { type = number }
 variable "read_capacity" { type = number }
+variable "iam_arn" { type = string }
+variable "role_name" { type = string }
+variable "creds_endpoint" { type = string }


### PR DESCRIPTION
Related PR (needed for this PR to work):
- https://github.com/cloudfoundry/cloud-service-broker/pull/888

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [x] Have you ran acceptance tests for the service under change?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

