### PR TITLE
test: only migrate data schema

### DIFF
--- a/acceptance-tests/helpers/dms/task.go
+++ b/acceptance-tests/helpers/dms/task.go
@@ -70,7 +70,7 @@ func waitForReplicationTaskCompletion(taskID, region string) {
 			gomega.Expect(statusReceiver.Percentages[0]).To(gomega.Equal(100))
 			return
 		default:
-			ginkgo.Fail("unexpected status")
+			ginkgo.Fail(fmt.Sprintf("unexpected status: %q", statusReceiver.Status[0]))
 		}
 
 		time.Sleep(taskPollPeriod)

--- a/acceptance-tests/mysql_data_migration_test.go
+++ b/acceptance-tests/mysql_data_migration_test.go
@@ -100,7 +100,7 @@ var _ = Describe("MySQL data migration", Label("mysql-migration"), func() {
 		defer targetEndpoint.Cleanup()
 
 		By("running the replication task")
-		dms.RunReplicationTask(replicationInstance, sourceEndpoint, targetEndpoint, metadata.Region, "%")
+		dms.RunReplicationTask(replicationInstance, sourceEndpoint, targetEndpoint, metadata.Region, sourceReceiver.DBName)
 
 		By("deleting the target service key to trigger data ownership update")
 		csbKey.Delete()


### PR DESCRIPTION
The database migration test started to fail because it could not copy across the "performance_insights" schema. This was likely triggered by a change in AWS, but the underlying cause is that the migration test tries to copy across all schemas, and we should restrict it to just copying across the data schema.

[#186350212](https://www.pivotaltracker.com/story/show/186350212)