### PR TITLE
feat: add Terraform 1.5

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -20,6 +20,7 @@ terraform_upgrade_path:
 - version: 1.1.9
 - version: 1.4.2
 - version: 1.4.4
+- version: 1.5.7
 terraform_binaries:
 - name: terraform
   version: 0.12.30
@@ -36,14 +37,15 @@ terraform_binaries:
 - name: terraform
   version: 1.1.9
   source: https://github.com/hashicorp/terraform/archive/v1.1.9.zip
-  default: false
 - name: terraform
   version: 1.4.2
   source: https://github.com/hashicorp/terraform/archive/v1.4.2.zip
-  default: false
 - name: terraform
   version: 1.4.4
   source: https://github.com/hashicorp/terraform/archive/v1.4.4.zip
+- name: terraform
+  version: 1.5.7
+  source: https://github.com/hashicorp/terraform/archive/v1.5.7.zip
   default: true
 - name: terraform-provider-aws
   version: 5.24.0


### PR DESCRIPTION
Adds Terraform 1.5.7
- At this stage Terraform 1.6 is not being added as it has a different license
- The question was raised as to whether we are shipping more Terraform versions than we need. Story [#186436578](https://www.pivotaltracker.com/story/show/186436578) has been created to look into this.

[#185536344](https://www.pivotaltracker.com/story/show/185536344)