### PR TITLE
fix: [Redis] use integer type in tls_port property

### DIFF
--- a/aws-redis.yml
+++ b/aws-redis.yml
@@ -330,7 +330,7 @@ bind:
       default: ${instance.details["host"]}
       overwrite: true
     - name: tls_port
-      type: string
+      type: integer
       default: ${instance.details["tls_port"]}
       overwrite: true
     - name: password

--- a/terraform/redis/cluster/binding/variables.tf
+++ b/terraform/redis/cluster/binding/variables.tf
@@ -4,5 +4,5 @@ variable "password" {
   type      = string
   sensitive = true
 }
-variable "tls_port" { type = string }
+variable "tls_port" { type = number }
 variable "reader_endpoint" { type = string }


### PR DESCRIPTION
[#183286656](https://www.pivotaltracker.com/story/show/183286656)

### Checklist:

* ~~[ ] Have you added Release Notes in the docs repositories?~~
* ~~[ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?~~
* ~~[ ] Have you ran acceptance tests for the service under change?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

