### PR TITLE
chore: replace mysql version not supported in GovCloud

### DIFF
--- a/providers/terraform-provider-csbmajorengineversion/csbmajorengineversion/datasource_majorengineversion_test.go
+++ b/providers/terraform-provider-csbmajorengineversion/csbmajorengineversion/datasource_majorengineversion_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Provider", func() {
 		Entry("postgres 15", "postgres", "15.3", "15", ""),
 		Entry("aurora-mysql 8", "aurora-mysql", "8.0", "8.0", ""),
 		Entry("aurora-mysql 8.0.mysql_aurora.3.03.1", "aurora-mysql", "8.0.mysql_aurora.3.03.1", "8.0", ""),
-		Entry("aurora-mysql 5.7.mysql_aurora.2.07.0", "aurora-mysql", "5.7.mysql_aurora.2.07.0", "5.7", ""),
+		Entry("aurora-mysql 5.7.mysql_aurora.2.07.10", "aurora-mysql", "5.7.mysql_aurora.2.07.10", "5.7", ""),
 		Entry("aurora-postgresql 14", "aurora-postgresql", "14", "14", ""),
 		Entry("aurora-postgresql 14.3", "aurora-postgresql", "14.3", "14", ""),
 		Entry("mysql 5.7", "mysql", "5.7", "5.7", ""),

--- a/terraform-tests/aurora_mysql_test.go
+++ b/terraform-tests/aurora_mysql_test.go
@@ -329,13 +329,13 @@ func testTerraformAuroraMysql(region string) {
 
 				session, _ = FailPlan(terraformProvisionDir, buildVars(defaultVars, map[string]any{
 					"auto_minor_version_upgrade": true,
-					"engine_version":             "5.7.mysql_aurora.2.07.0",
+					"engine_version":             "5.7.mysql_aurora.2.07.10",
 				}))
 
 				Expect(session.ExitCode()).NotTo(Equal(0))
 				msgs = string(session.Out.Contents())
 				Expect(msgs).To(ContainSubstring(`Error: Resource postcondition failed`))
-				Expect(msgs).To(ContainSubstring(`A Major engine version should be specified when auto_minor_version_upgrade is enabled. Expected engine version: 5.7 - got: 5.7.mysql_aurora.2.07.0`))
+				Expect(msgs).To(ContainSubstring(`A Major engine version should be specified when auto_minor_version_upgrade is enabled. Expected engine version: 5.7 - got: 5.7.mysql_aurora.2.07.10`))
 			})
 		})
 
@@ -365,19 +365,19 @@ func testTerraformAuroraMysql(region string) {
 			It("should not complain about postcondition and create the instance", func() {
 				plan := ShowPlan(terraformProvisionDir, buildVars(defaultVars, map[string]any{
 					"auto_minor_version_upgrade": false,
-					"engine_version":             "5.7.mysql_aurora.2.07.0",
+					"engine_version":             "5.7.mysql_aurora.2.07.10",
 				}))
 
 				Expect(AfterValuesForType(plan, "aws_rds_cluster")).To(
 					MatchKeys(IgnoreExtras, Keys{
-						"engine_version": Equal("5.7.mysql_aurora.2.07.0"),
+						"engine_version": Equal("5.7.mysql_aurora.2.07.10"),
 					}),
 				)
 
 				Expect(AfterValuesForType(plan, "aws_rds_cluster_instance")).To(
 					MatchKeys(IgnoreExtras, Keys{
 						"auto_minor_version_upgrade": BeFalse(),
-						"engine_version":             Equal("5.7.mysql_aurora.2.07.0"),
+						"engine_version":             Equal("5.7.mysql_aurora.2.07.10"),
 					}),
 				)
 			})


### PR DESCRIPTION
[#186311950](https://www.pivotaltracker.com/story/show/186311950)

### Checklist:

* ~~[ ] Have you added Release Notes in the docs repositories?~~
* [x] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

