### PR TITLE
fix: runway connectivity issues in binding operation

### DIFF
--- a/aws-postgresql.yml
+++ b/aws-postgresql.yml
@@ -422,13 +422,16 @@ examples:
   plan_id: de7dbcee-1c8d-11ed-9904-5f435c1e2316
   provision_params: {"publicly_accessible": true, "provider_verify_certificate": false}
   bind_params: {}
+  bind_can_fail: true
 - name: default-with-features
   description: Create a medium multiaz PostgreSQL instance
   plan_id: de7dbcee-1c8d-11ed-9904-5f435c1e2316
   provision_params: {"publicly_accessible": true, "multi_az": true, "storage_encrypted": true, "provider_verify_certificate": false}
   bind_params: {}
+  bind_can_fail: true
 - name: default-with-maintenance-window
   description: Create a small PostgreSQL instance with encrypted storage
   plan_id: de7dbcee-1c8d-11ed-9904-5f435c1e2316
   provision_params: {"maintenance_day": "Thu", "maintenance_start_hour": "15", "maintenance_start_min": "30", "maintenance_end_hour": "17", "maintenance_end_min": "00", "publicly_accessible": true, "provider_verify_certificate": false}
   bind_params: {}
+  bind_can_fail: true


### PR DESCRIPTION
Runway connectivity issues exist in binding operation. Reviewing the other PostgreSQL services we have noticed that we use the bind_can_fail flag. For consistency we assign the same configuration to the test and postpone the decision to solve the connectivity problems associated with Runway

[#186332128](https://www.pivotaltracker.com/story/show/186332128)



### Checklist:

* ~~[ ] Have you added Release Notes in the docs repositories?~~
* ~~[ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?~~
* ~~[ ] Have you ran acceptance tests for the service under change?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

