### PR TITLE
test: update test app for AWS lib change

### DIFF
--- a/acceptance-tests/apps/s3app/internal/app/upload.go
+++ b/acceptance-tests/apps/s3app/internal/app/upload.go
@@ -17,7 +17,7 @@ func handleUpload(w http.ResponseWriter, r *http.Request, filename string, clien
 		Bucket:        aws.String(client.Credentials.BucketName),
 		Key:           aws.String(filename),
 		Body:          r.Body,
-		ContentLength: r.ContentLength,
+		ContentLength: &r.ContentLength,
 	})
 	if err != nil {
 		fail(w, http.StatusFailedDependency, "Error uploading file part %q: %s", filename, err)

--- a/acceptance-tests/apps/s3app/internal/app/upload_with_acl.go
+++ b/acceptance-tests/apps/s3app/internal/app/upload_with_acl.go
@@ -24,7 +24,7 @@ func HandleUploadWithACL(client *credentials.Client, acl string) http.HandlerFun
 				Bucket:        aws.String(client.Credentials.BucketName),
 				Key:           aws.String(filename),
 				Body:          r.Body,
-				ContentLength: r.ContentLength,
+				ContentLength: &r.ContentLength,
 				ACL:           types.ObjectCannedACL(acl),
 			})
 			if err != nil {


### PR DESCRIPTION
Looks like there have been some Go type changes in the AWS library, presumably introduced in #1304. This changes the test app to match the library.

