### PR TITLE
revert: "build(deps): bump terraform providers"

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -48,8 +48,8 @@ terraform_binaries:
   source: https://github.com/hashicorp/terraform/archive/v1.5.7.zip
   default: true
 - name: terraform-provider-aws
-  version: 5.30.0
-  source: https://github.com/terraform-providers/terraform-provider-aws/archive/v5.30.0.zip
+  version: 5.29.0
+  source: https://github.com/terraform-providers/terraform-provider-aws/archive/v5.29.0.zip
 - name: terraform-provider-random
   version: 3.6.0
   source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.6.0.zip
@@ -62,13 +62,13 @@ terraform_binaries:
   provider: cyrilgdn/postgresql
   url_template: https://github.com/cyrilgdn/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
 - name: terraform-provider-csbpg
-  version: 1.2.13
-  source: https://github.com/cloudfoundry/terraform-provider-csbpg/archive/v1.2.13.zip
+  version: 1.2.12
+  source: https://github.com/cloudfoundry/terraform-provider-csbpg/archive/v1.2.12.zip
   provider: cloud-service-broker/csbpg
   url_template: https://github.com/cloudfoundry/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
 - name: terraform-provider-csbmysql
-  version: 1.2.18
-  source: https://github.com/cloudfoundry/terraform-provider-csbmysql/archive/v1.2.18.zip
+  version: 1.2.17
+  source: https://github.com/cloudfoundry/terraform-provider-csbmysql/archive/v1.2.17.zip
   provider: cloud-service-broker/csbmysql
   url_template: https://github.com/cloudfoundry/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
 - name: terraform-provider-csbdynamodbns
@@ -80,8 +80,8 @@ terraform_binaries:
   provider: cloudfoundry.org/cloud-service-broker/csbmajorengineversion
   url_template: ./providers/build/cloudfoundry.org/cloud-service-broker/csbmajorengineversion/${version}/${os}_${arch}/${name}_v${version}
 - name: terraform-provider-csbsqlserver
-  version: 1.0.4
-  source: https://github.com/cloudfoundry/terraform-provider-csbsqlserver/archive/v1.0.4.zip
+  version: 1.0.3
+  source: https://github.com/cloudfoundry/terraform-provider-csbsqlserver/archive/v1.0.3.zip
   provider: cloudfoundry.org/cloud-service-broker/csbsqlserver
   url_template: https://github.com/cloudfoundry/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
 env_config_mapping:


### PR DESCRIPTION
An issue was discovered in the AWS terraform provider v5.30.0: https://github.com/hashicorp/terraform-provider-aws/pull/34812

This reverts commit 03360669adc35de2938b5100b274ce1f7c2ed7f2.

[#186655365](https://www.pivotaltracker.com/story/show/186655365)