### PR TITLE
feat: restrict upgrade to v1.10 only

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -8,41 +8,9 @@ platforms:
   arch: amd64
 # - os: darwin
 #   arch: amd64
-terraform_state_provider_replacements:
-  registry.terraform.io/-/aws: "registry.terraform.io/hashicorp/aws"
-  registry.terraform.io/-/random: "registry.terraform.io/hashicorp/random"
-  registry.terraform.io/-/mysql: "registry.terraform.io/hashicorp/mysql"
-  registry.terraform.io/-/postgresql: "registry.terraform.io/cyrilgdn/postgresql"
 terraform_upgrade_path:
-- version: 0.13.7
-- version: 0.14.11
-- version: 1.0.11
-- version: 1.1.9
-- version: 1.4.2
-- version: 1.4.4
 - version: 1.5.7
 terraform_binaries:
-- name: terraform
-  version: 0.12.30
-  source: https://github.com/hashicorp/terraform/archive/v0.12.30.zip  
-- name: terraform
-  version: 0.13.7
-  source: https://github.com/hashicorp/terraform/archive/v0.13.7.zip
-- name: terraform
-  version: 0.14.11
-  source: https://github.com/hashicorp/terraform/archive/v0.14.11.zip
-- name: terraform
-  version: 1.0.11
-  source: https://github.com/hashicorp/terraform/archive/v1.0.11.zip
-- name: terraform
-  version: 1.1.9
-  source: https://github.com/hashicorp/terraform/archive/v1.1.9.zip
-- name: terraform
-  version: 1.4.2
-  source: https://github.com/hashicorp/terraform/archive/v1.4.2.zip
-- name: terraform
-  version: 1.4.4
-  source: https://github.com/hashicorp/terraform/archive/v1.4.4.zip
 - name: terraform
   version: 1.5.7
   source: https://github.com/hashicorp/terraform/archive/v1.5.7.zip
@@ -53,14 +21,6 @@ terraform_binaries:
 - name: terraform-provider-random
   version: 3.6.0
   source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.6.0.zip
-- name: terraform-provider-mysql
-  version: 1.9.0
-  source: https://github.com/terraform-providers/terraform-provider-mysql/archive/v1.9.0.zip
-- name: terraform-provider-postgresql
-  version: 1.21.0
-  source: https://github.com/cyrilgdn/terraform-provider-postgresql/archive/v1.21.0.zip
-  provider: cyrilgdn/postgresql
-  url_template: https://github.com/cyrilgdn/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
 - name: terraform-provider-csbpg
   version: 1.2.13
   source: https://github.com/cloudfoundry/terraform-provider-csbpg/archive/v1.2.13.zip

--- a/terraform/mysql/bind/provider.tf
+++ b/terraform/mysql/bind/provider.tf
@@ -12,13 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-provider "mysql" {
-  endpoint = format("%s:%d", var.hostname, local.port)
-  username = var.admin_username
-  password = var.admin_password
-  tls      = true
-}
-
 provider "csbmysql" {
   database = var.db_name
   password = var.admin_password

--- a/terraform/postgresql/bind/provider.tf
+++ b/terraform/postgresql/bind/provider.tf
@@ -12,16 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-provider "postgresql" {
-  host      = var.hostname
-  port      = local.port
-  username  = var.admin_username
-  password  = var.admin_password
-  superuser = false
-  database  = var.db_name
-  sslmode   = var.provider_verify_certificate ? "verify-full" : "require"
-}
-
 provider "csbpg" {
   host            = var.hostname
   port            = local.port


### PR DESCRIPTION
In order to reduce the size of the brokerpak, obsolete Terraform providers have been removed. As a result, to get to this version through upgrading, you must upgrade to v1.10 first and upgrade all service instances to v1.10. This can be done via "cf upgrade-service", or for bulk upgrades consider the plugin: https://github.com/cloudfoundry/upgrade-all-services-cli-plugin You can then upgrade to this version, and again upgrade all the service instances.

[#186588913](https://www.pivotaltracker.com/story/show/186588913)

