### PR TITLE
fix: disable encryption since it's unsupported for db.t3.micro

### DIFF
--- a/acceptance-tests/mssql_data_migration_test.go
+++ b/acceptance-tests/mssql_data_migration_test.go
@@ -45,6 +45,8 @@ var _ = Describe("MSSQL data migration", Label("mssql-migration"), func() {
 					"EngineVersion":   "14.00.3401.7.v1",
 					"MultiAZ":         false,
 					"DBInstanceClass": "db.t3.micro",
+
+					"StorageEncrypted": false,
 				},
 			}),
 		)


### PR DESCRIPTION
Fixes an issue introduced in:
- https://github.com/cloudfoundry/csb-brokerpak-aws/pull/1451

Failing pipeline:
- https://runway-ci.eng.vmware.com/teams/service-enablement/pipelines/aws-csb/jobs/cf-test/builds/226#L658206ee:236


### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

