### PR TITLE
fix: disable auto_minor_version_upgrade

### DIFF
--- a/acceptance-tests/upgrade/update_and_upgrade_aurora_postgresql_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_aurora_postgresql_test.go
@@ -32,6 +32,8 @@ var _ = Describe("UpgradeAuroraPostgreSQLTest", Label("aurora-postgresql", "upgr
 						"serverless_min_capacity": 0.5,
 						"serverless_max_capacity": 2,
 						"instance_class":          "db.serverless",
+
+						"auto_minor_version_upgrade": false,
 					}),
 				services.WithBroker(serviceBroker),
 			)


### PR DESCRIPTION
Complements PR:
- https://github.com/cloudfoundry/csb-brokerpak-aws/pull/1483

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

