### PR TITLE
test(acceptance): simplify aurora-postgres update and upgrade test

### DIFF
--- a/acceptance-tests/upgrade/update_and_upgrade_aurora_postgresql_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_aurora_postgresql_test.go
@@ -27,13 +27,11 @@ var _ = Describe("UpgradeAuroraPostgreSQLTest", Label("aurora-postgresql", "upgr
 				services.WithPlan("default"),
 				services.WithParameters(
 					map[string]any{
-						"engine_version":          "13.10",
+						"engine_version":          "13",
 						"cluster_instances":       1,
 						"serverless_min_capacity": 0.5,
-						"serverless_max_capacity": 2,
+						"serverless_max_capacity": 4,
 						"instance_class":          "db.serverless",
-
-						"auto_minor_version_upgrade": false,
 					}),
 				services.WithBroker(serviceBroker),
 			)
@@ -74,15 +72,9 @@ var _ = Describe("UpgradeAuroraPostgreSQLTest", Label("aurora-postgresql", "upgr
 			got = appTwo.GET("%s/%s", schema, keyOne).String()
 			Expect(got).To(Equal(valueOne))
 
-			By("updating the instance plan")
-			// It applies changes in Terraform:
-			// apply_immediately = true
-			// changes the lifecycle of the resource aws_rds_cluster_parameter_group
-			// when the new resource aws_rds_cluster_parameter_group is created and the changes are applied immediately,
-			// we can upgrade the version
+			By("updating the instance version")
 			serviceInstance.Update(services.WithParameters(map[string]any{
-				"engine_version":             "13.11",
-				"auto_minor_version_upgrade": false,
+				"engine_version": "14",
 			}))
 
 			By("checking previously written data still accessible")


### PR DESCRIPTION
changed to increase capacity on serverless instance instead of doing extra updates to change instance class. aurora seems to be particularly problematic by itself on upgrades, even through the console.
In this test we want to test that the brokerpak has been changed in a way that allows for updates and upgrades and not aws behavior.

[#186886707](https://www.pivotaltracker.com/story/show/186886707)

### Checklist:

~~* [ ] Have you added Release Notes in the docs repositories?~~
~~* [ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?~~
* [ ] Have you ran acceptance tests for the service under change?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

