### PR TITLE
chore: specify go 1.22.0 in go.mod

### DIFF
--- a/acceptance-tests/apps/dynamodbnsapp/go.mod
+++ b/acceptance-tests/apps/dynamodbnsapp/go.mod
@@ -1,6 +1,6 @@
 module dynamodbnsapp
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.24.1

--- a/acceptance-tests/apps/dynamodbtableapp/go.mod
+++ b/acceptance-tests/apps/dynamodbtableapp/go.mod
@@ -1,6 +1,6 @@
 module dynamodbtableapp
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.24.1

--- a/acceptance-tests/apps/mssqlapp/go.mod
+++ b/acceptance-tests/apps/mssqlapp/go.mod
@@ -1,6 +1,6 @@
 module mssqlapp
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/cloudfoundry-community/go-cfenv v1.18.0

--- a/acceptance-tests/apps/mysqlapp/go.mod
+++ b/acceptance-tests/apps/mysqlapp/go.mod
@@ -1,6 +1,6 @@
 module mysqlapp
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/cloudfoundry-community/go-cfenv v1.18.0

--- a/acceptance-tests/apps/postgresqlapp/go.mod
+++ b/acceptance-tests/apps/postgresqlapp/go.mod
@@ -1,6 +1,6 @@
 module postgresqlapp
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/cloudfoundry-community/go-cfenv v1.18.0

--- a/acceptance-tests/apps/redisapp/go.mod
+++ b/acceptance-tests/apps/redisapp/go.mod
@@ -1,6 +1,6 @@
 module redisapp
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/cloudfoundry-community/go-cfenv v1.18.0

--- a/acceptance-tests/apps/s3app/go.mod
+++ b/acceptance-tests/apps/s3app/go.mod
@@ -1,6 +1,6 @@
 module s3app
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.24.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module csbbrokerpakaws
 
-go 1.22
+go 1.22.0
 
 require (
 	code.cloudfoundry.org/jsonry v1.1.4

--- a/providers/terraform-provider-csbdynamodbns/go.mod
+++ b/providers/terraform-provider-csbdynamodbns/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/csb-brokerpak-aws/terraform-provider-dynamodbns
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.24.1

--- a/providers/terraform-provider-csbmajorengineversion/go.mod
+++ b/providers/terraform-provider-csbmajorengineversion/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/csb-brokerpak-aws/terraform-provider-majorengineversion
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.24.1


### PR DESCRIPTION
Related PRs:
- https://github.com/pivotal/cloud-service-broker-ci/pull/795

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

