### PR TITLE
chore: stop checking go version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,6 @@ help: ## list Makefile targets
 
 ###### Setup ##################################################################
 IAAS=aws
-GO-VERSION = 1.22.0
-GO-VER = go$(GO-VERSION)
 CSB_VERSION := $(or $(CSB_VERSION), $(shell grep 'github.com/cloudfoundry/cloud-service-broker' go.mod | grep -v replace | awk '{print $$NF}' | sed -e 's/v//'))
 CSB_RELEASE_VERSION := $(CSB_VERSION) # this doesnt work well if we did make latest-csb.
 
@@ -43,17 +41,8 @@ GET_CSB="env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags $(LDFLAGS) 
 
 ###### Targets ################################################################
 
-.PHONY: deps-go-binary
-deps-go-binary:
-ifeq ($(SKIP_GO_VERSION_CHECK),)
-	@@if [ "$$(go version | awk '{print $$3}')" != "${GO-VER}" ]; then \
-		echo "Go version does not match: expected: ${GO-VER}, got $$(go version | awk '{print $$3}')"; \
-		exit 1; \
-	fi
-endif
-
 .PHONY: build
-build: deps-go-binary $(IAAS)-services-*.brokerpak ## build brokerpak
+build: $(IAAS)-services-*.brokerpak ## build brokerpak
 
 $(IAAS)-services-*.brokerpak: *.yml terraform/*/*/*.tf terraform/*/*/*/*.tf providers | $(PAK_BUILD_CACHE_PATH)
 	$(RUN_CSB) pak build

--- a/providers/terraform-provider-csbdynamodbns/Makefile
+++ b/providers/terraform-provider-csbdynamodbns/Makefile
@@ -1,7 +1,5 @@
 .DEFAULT_GOAL = help
 
-GO-VERSION = 1.22.0
-GO-VER = go$(GO-VERSION)
   GO = go
   GOFMT = gofmt
 
@@ -14,10 +12,10 @@ help: ## list Makefile targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: test
-test: version download checkfmt checkimports vet ginkgo ## run all build, static analysis, and test steps
+test: download checkfmt checkimports vet ginkgo ## run all build, static analysis, and test steps
 
 .PHONY: build
-build: version download checkfmt checkimports vet ../build/cloudfoundry.org ## build the provider
+build: download checkfmt checkimports vet ../build/cloudfoundry.org ## build the provider
 
 ../build/cloudfoundry.org: *.go */*.go
 	mkdir -p ../build/cloudfoundry.org/cloud-service-broker/csbdynamodbns/$(VERSION)/linux_amd64
@@ -70,10 +68,3 @@ ginkgo-coverage: ## ginkgo tests coverage score
 generate: ## generate test fakes
 	cd csbdynamodbns; $(GO) generate; cd ..
 
-.PHONY: version
-version:
-	@@$(GO) version
-	@@if [ "$$(${GO} version | awk '{print $$3}')" != "${GO-VER}" ]; then \
-		echo "Go version does not match: expected: ${GO-VER}, got $$(${GO} version | awk '{print $$3}')"; \
-		exit 1; \
-	fi

--- a/providers/terraform-provider-csbmajorengineversion/Makefile
+++ b/providers/terraform-provider-csbmajorengineversion/Makefile
@@ -1,7 +1,5 @@
 .DEFAULT_GOAL = help
 
-GO-VERSION = 1.22.0
-GO-VER = go$(GO-VERSION)
   GO = go
   GOFMT = gofmt
 
@@ -12,10 +10,10 @@ help: ## list Makefile targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: test
-test: version download checkfmt checkimports vet ginkgo ## run all build, static analysis, and test steps
+test: download checkfmt checkimports vet ginkgo ## run all build, static analysis, and test steps
 
 .PHONY: build
-build: version download checkfmt checkimports vet build_binaries_in_cloudfoundry_namespace ## build the provider
+build: download checkfmt checkimports vet build_binaries_in_cloudfoundry_namespace ## build the provider
 
 
 .PHONY: build_binaries_in_cloudfoundry_namespace
@@ -60,11 +58,3 @@ ginkgo: ## run the tests with Ginkgo
 ginkgo-coverage: ## ginkgo tests coverage score
 	go test -coverprofile=/tmp/csbmajorengineversion-coverage.out ./...
 	go tool cover -func /tmp/csbmajorengineversion-coverage.out | grep total
-
-.PHONY: version
-version:
-	@@$(GO) version
-	@@if [ "$$(${GO} version | awk '{print $$3}')" != "${GO-VER}" ]; then \
-		echo "Go version does not match: expected: ${GO-VER}, got $$(${GO} version | awk '{print $$3}')"; \
-		exit 1; \
-	fi


### PR DESCRIPTION
[#187027977](https://www.pivotaltracker.com/story/show/187027977)

Before Go 1.21:
- The go directive was advisory only; now it is a mandatory requirement
- The go directive didn't allow specifying patch versions

So, by specifying the patch version in go.mod:
- Noone can unknowingly test, run or build this project using an older version of go
- The required Go toolchain can be downloaded automatically

Therefore, checking the current go version in Makefile is no longer needed.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

