### PR TITLE
feat: align SQS binding field names with legacy broker

### DIFF
--- a/aws-sqs.yml
+++ b/aws-sqs.yml
@@ -53,12 +53,12 @@ provision:
     - field_name: arn
       type: string
       details: ARN for the queue
-    - field_name: url
-      type: string
-      details: URL for the queue
-    - field_name: name
-      type: string
-      details: name for the queue
     - field_name: region
       type: string
       details: AWS region for the queue
+    - field_name: queue_name
+      type: string
+      details: name for the queue
+    - field_name: queue_url
+      type: string
+      details: URL for the queue

--- a/terraform/sqs/provision/outputs.tf
+++ b/terraform/sqs/provision/outputs.tf
@@ -1,4 +1,4 @@
 output "arn" { value = aws_sqs_queue.queue.arn }
-output "url" { value = aws_sqs_queue.queue.id }
-output "name" { value = aws_sqs_queue.queue.name }
 output "region" { value = var.region }
+output "queue_url" { value = aws_sqs_queue.queue.id }
+output "queue_name" { value = aws_sqs_queue.queue.name }


### PR DESCRIPTION
Renames some SQS field names to have the same name as is used in the legacy AWS broker. This will maximise compatibility.

[#186787985](https://www.pivotaltracker.com/story/show/186787985)