### PR TITLE
feat: bindings for SQS (experimental)

### DIFF
--- a/aws-sqs.yml
+++ b/aws-sqs.yml
@@ -64,16 +64,14 @@ provision:
       details: URL for the queue
 bind:
   plan_inputs: []
-  user_inputs:
-    - field_name: aws_access_key_id
-      type: string
-      details: AWS access key
-      default: ${config("aws.access_key_id")}
-    - field_name: aws_secret_access_key
-      type: string
-      details: AWS secret key
-      default: ${config("aws.secret_access_key")}
+  user_inputs: []
   computed_inputs:
+    - name: aws_access_key_id
+      type: string
+      default: ${config("aws.access_key_id")}
+    - name: aws_secret_access_key
+      type: string
+      default: ${config("aws.secret_access_key")}
     - name: arn
       default: ${instance.details["arn"]}
       overwrite: true

--- a/aws-sqs.yml
+++ b/aws-sqs.yml
@@ -62,3 +62,41 @@ provision:
     - field_name: queue_url
       type: string
       details: URL for the queue
+bind:
+  plan_inputs: []
+  user_inputs:
+    - field_name: aws_access_key_id
+      type: string
+      details: AWS access key
+      default: ${config("aws.access_key_id")}
+    - field_name: aws_secret_access_key
+      type: string
+      details: AWS secret key
+      default: ${config("aws.secret_access_key")}
+  computed_inputs:
+    - name: arn
+      default: ${instance.details["arn"]}
+      overwrite: true
+      type: string
+    - name: region
+      default: ${instance.details["region"]}
+      overwrite: true
+      type: string
+    - name: user_name
+      default: csb-${request.binding_id}
+      overwrite: true
+      type: string
+  template_refs:
+    data: terraform/sqs/bind/data.tf
+    main: terraform/sqs/bind/main.tf
+    outputs: terraform/sqs/bind/outputs.tf
+    provider: terraform/sqs/bind/provider.tf
+    versions: terraform/sqs/bind/versions.tf
+    variables: terraform/sqs/bind/variables.tf
+  outputs:
+    - field_name: access_key_id
+      type: string
+      details: AWS access key
+    - field_name: secret_access_key
+      type: string
+      details: AWS secret access key

--- a/integration-tests/sqs_test.go
+++ b/integration-tests/sqs_test.go
@@ -167,4 +167,59 @@ var _ = Describe("SQS", Label("SQS"), func() {
 			Entry(nil, "aws_secret_access_key", "fake-aws-secret-access-key"),
 		)
 	})
+
+	Describe("bind a service ", func() {
+		It("return the bind values from terraform output", func() {
+			err := mockTerraform.SetTFState([]testframework.TFStateValue{
+				{
+					Name:  "access_key_id",
+					Type:  "string",
+					Value: "initial.access.key.id.test",
+				},
+				{
+					Name:  "secret_access_key",
+					Type:  "string",
+					Value: "initial.secret.access.key.test",
+				},
+				{
+					Name:  "region",
+					Type:  "string",
+					Value: "ap-northeast-3",
+				},
+				{
+					Name:  "arn",
+					Type:  "string",
+					Value: "arn:aws:sqs::ap-northeast-3::example",
+				},
+				{
+					Name:  "queue_name",
+					Type:  "string",
+					Value: "example_name",
+				},
+				{
+					Name:  "queue_url",
+					Type:  "string",
+					Value: "example_url",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			instanceID, err := broker.Provision(sqsServiceName, sqsCustomFIFOPlanName, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			bindResult, err := broker.Bind(sqsServiceName, sqsCustomFIFOPlanName, instanceID, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(bindResult).To(
+				Equal(map[string]any{
+					"access_key_id":     "initial.access.key.id.test",
+					"secret_access_key": "initial.secret.access.key.test",
+					"region":            "ap-northeast-3",
+					"arn":               "arn:aws:sqs::ap-northeast-3::example",
+					"queue_name":        "example_name",
+					"queue_url":         "example_url",
+				}),
+			)
+		})
+	})
 })

--- a/terraform/sqs/bind/data.tf
+++ b/terraform/sqs/bind/data.tf
@@ -1,0 +1,15 @@
+data "aws_iam_policy_document" "user_policy" {
+  statement {
+    sid = "sqsAccess"
+    actions = [
+      "sqs:SendMessage",
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+      "sqs:PurgeQueue",
+      "sqs:GetQueueAttributes"
+    ]
+    resources = [
+      var.arn
+    ]
+  }
+}

--- a/terraform/sqs/bind/main.tf
+++ b/terraform/sqs/bind/main.tf
@@ -1,0 +1,15 @@
+resource "aws_iam_user" "user" {
+  name = var.user_name
+  path = "/cf/"
+}
+
+resource "aws_iam_access_key" "access_key" {
+  user = aws_iam_user.user.name
+}
+
+resource "aws_iam_user_policy" "user_policy" {
+  name = format("%s-p", var.user_name)
+  user = aws_iam_user.user.name
+
+  policy = data.aws_iam_policy_document.user_policy.json
+}

--- a/terraform/sqs/bind/outputs.tf
+++ b/terraform/sqs/bind/outputs.tf
@@ -1,0 +1,8 @@
+output "access_key_id" {
+  value     = aws_iam_access_key.access_key.id
+  sensitive = true
+}
+output "secret_access_key" {
+  value     = aws_iam_access_key.access_key.secret
+  sensitive = true
+}

--- a/terraform/sqs/bind/provider.tf
+++ b/terraform/sqs/bind/provider.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  region     = var.region
+  access_key = var.aws_access_key_id
+  secret_key = var.aws_secret_access_key
+}

--- a/terraform/sqs/bind/variables.tf
+++ b/terraform/sqs/bind/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_access_key_id" {
+  type      = string
+  sensitive = true
+}
+variable "aws_secret_access_key" {
+  type      = string
+  sensitive = true
+}
+variable "region" { type = string }
+variable "arn" { type = string }
+variable "user_name" { type = string }

--- a/terraform/sqs/bind/versions.tf
+++ b/terraform/sqs/bind/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}


### PR DESCRIPTION
- Introduces bindings for SQS
- A binding is a IAM User with a key/secret and a policy
- Using an AWS key/secret is no longer considered the best way to give access to an AWS resource. However it is the way that the legacy broker gives access, so for maximum compatibility it makes sense to do the same. A more modern approach would be to use IAM Roles Anywhere. But using that would likely involve big changes to existing apps, and we are currently trying to prioritise compatibility over modernity.
- The policy for an SQS queue is hard-coded and minimal. It gives less permissions that the legacy broker did, and we will need to add more permissions for DLQs. The aim is that for an action that a user should do via the broker (e.g. delete the queue), that permission is not accessible via a binding. If needed we can also give more permissions later (whereas it would be harder to take them away). The rationale is that we don't want an app to change a queue definition without the broker becoming aware, otherwise the broker will undo the change during the next upgrade.

[#186787985](https://www.pivotaltracker.com/story/show/186787985)