### PR TITLE
chore: use --update-if-exists flag when pushing broker

### DIFF
--- a/scripts/push-broker.sh
+++ b/scripts/push-broker.sh
@@ -139,4 +139,4 @@ if [[ -z ${BROKER_NAME} ]]; then
   BROKER_NAME=csb-$USER
 fi
 
-cf create-service-broker "${BROKER_NAME}" "${SECURITY_USER_NAME}" "${SECURITY_USER_PASSWORD}" https://$(LANG=EN cf app "${APP_NAME}" | grep 'routes:' | cut -d ':' -f 2 | xargs) --space-scoped || cf update-service-broker "${BROKER_NAME}" "${SECURITY_USER_NAME}" "${SECURITY_USER_PASSWORD}" https://$(LANG=EN cf app "${APP_NAME}" | grep 'routes:' | cut -d ':' -f 2 | xargs)
+cf create-service-broker "${BROKER_NAME}" "${SECURITY_USER_NAME}" "${SECURITY_USER_PASSWORD}" https://$(LANG=EN cf app "${APP_NAME}" | grep 'routes:' | cut -d ':' -f 2 | xargs) --space-scoped --update-if-exists


### PR DESCRIPTION
Previously we would always try and create the broker, and if that failed (for any reason) then attempt to update it. This resulted in output that sometimes confused users.