### PR TITLE
fix: aws terraform-tests performance_insights_retention_period

### DIFF
--- a/terraform-tests/mssql_test.go
+++ b/terraform-tests/mssql_test.go
@@ -739,19 +739,13 @@ var _ = Describe("mssql", Label("mssql-terraform"), Ordered, func() {
 		})
 
 		When("an invalid retention period is passed", func() {
-			It("doesn't detect any errors and plan finishes succesfully", func() {
-				// invalid values for the retention_period are handled by the IAAS not Terraform
-				plan := ShowPlan(terraformProvisionDir, buildVars(defaultVars, requiredVars, map[string]any{
+			It("should fail and return a descriptive error message", func() {
+				session, _ := FailPlan(terraformProvisionDir, buildVars(defaultVars, requiredVars, map[string]any{
 					"performance_insights_enabled":          true,
 					"performance_insights_retention_period": 13,
 				}))
-
-				Expect(AfterValuesForType(plan, "aws_db_instance")).To(
-					MatchKeys(IgnoreExtras, Keys{
-						"performance_insights_enabled":          BeTrue(),
-						"performance_insights_retention_period": BeNumerically("==", 13),
-					}),
-				)
+				Expect(session.ExitCode()).NotTo(Equal(0))
+				Expect(session).To(gbytes.Say("expected performance_insights_retention_period to be divisible by 31, got: 13"))
 			})
 		})
 	})


### PR DESCRIPTION
[#187103734](https://www.pivotaltracker.com/story/show/187103734)

Recently, a new PR for validating this property was merged: https://github.com/hashicorp/terraform-provider-aws/pull/35870

I believe it's valuable to have our tests break when changes like this are introduced in the providers. Therefore, we should try have behaviours such as this encoded in our tests. Things like: "invalid values for property X are not validated by TF".

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

