### PR TITLE
fix: Fifo properties should only be set if the queue is of type FIFO

### DIFF
--- a/aws-sqs.yml
+++ b/aws-sqs.yml
@@ -77,21 +77,23 @@ provision:
       default: 5
     - field_name: deduplication_scope
       type: string
+      default: null
+      nullable: true
       details: |
         Determines the scope of deduplication for messages within the FIFO queue.
         Allowed values:
         * `messageGroup`: deduplication is performed within each message group
         * `queue`: deduplication across the entire queue
-      default: queue
     - field_name: fifo_throughput_limit
       type: string
+      default: null
+      nullable: true
       details: |
         Manages the throughput limit for the FIFO queue to optimize processing capabilities.
         Allowed values: 
         * `perQueue`: standard throughput limits
         * `perMessageGroupId`: for high throughput mode
         When High throughput Mode is ON, the value for `deduplication_scope` must be `messageGroup` or the operation fails
-      default: perQueue
   computed_inputs:
     - name: instance_name
       default: csb-sqs-${request.instance_id}
@@ -172,5 +174,5 @@ examples:
 - name: fifo
   description: FIFO queue
   plan_id: 093c1060-c1c0-11ee-8b97-ff07a1127dae
-  provision_params: {}
+  provision_params: { "fifo_throughput_limit": "perMessageGroupId", "deduplication_scope": "messageGroup"}
   bind_params: {}

--- a/aws-sqs.yml
+++ b/aws-sqs.yml
@@ -84,6 +84,7 @@ provision:
         Allowed values:
         * `messageGroup`: deduplication is performed within each message group
         * `queue`: deduplication across the entire queue
+        If not defined for a FIFO queue it defaults to `queue`.
     - field_name: fifo_throughput_limit
       type: string
       default: null
@@ -93,7 +94,8 @@ provision:
         Allowed values: 
         * `perQueue`: standard throughput limits
         * `perMessageGroupId`: for high throughput mode
-        When High throughput Mode is ON, the value for `deduplication_scope` must be `messageGroup` or the operation fails
+        When High throughput Mode is ON, the value for `deduplication_scope` must be `messageGroup` or the operation fails.
+        If not defined for a FIFO queue it defaults to `perQueue`.
   computed_inputs:
     - name: instance_name
       default: csb-sqs-${request.instance_id}
@@ -174,5 +176,5 @@ examples:
 - name: fifo
   description: FIFO queue
   plan_id: 093c1060-c1c0-11ee-8b97-ff07a1127dae
-  provision_params: { "fifo_throughput_limit": "perMessageGroupId", "deduplication_scope": "messageGroup"}
+  provision_params: {"fifo_throughput_limit": "perMessageGroupId", "deduplication_scope": "messageGroup"}
   bind_params: {}


### PR DESCRIPTION
`deduplication_scope` and `fifo_throughput_limit` do not apply for standard queues and they will throw error if attempted to be set (e.g. because there is a default)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

