### PR TITLE
fix: test fifo properties are validated by the IAAS not TF

### DIFF
--- a/terraform-tests/sqs_test.go
+++ b/terraform-tests/sqs_test.go
@@ -72,8 +72,6 @@ var _ = Describe("SQS", Label("SQS-terraform"), Ordered, func() {
 					"max_message_size":           BeNumerically("==", 262144),
 					"delay_seconds":              BeZero(),
 					"receive_wait_time_seconds":  BeZero(),
-					"deduplication_scope":        BeNil(),
-					"fifo_throughput_limit":      BeNil(),
 					"tags_all": MatchAllKeys(Keys{
 						"label1": Equal("value1"),
 					}),

--- a/terraform-tests/sqs_test.go
+++ b/terraform-tests/sqs_test.go
@@ -119,6 +119,26 @@ var _ = Describe("SQS", Label("SQS-terraform"), Ordered, func() {
 		})
 	})
 
+	Context("Standard Queue", func() {
+		When("parameters exclusive to FIFO queues are passed to an standard queue", func() {
+			It("doesn't detect any errors and plan finishes succesfully", func() {
+				// invalid values for these properties are handled by the IAAS not Terraform
+				plan := ShowPlan(terraformProvisionDir, buildVars(defaultVars, map[string]any{
+					"fifo":                  false,
+					"deduplication_scope":   "queue",
+					"fifo_throughput_limit": "perQueue",
+				}))
+				Expect(AfterValuesForType(plan, "aws_sqs_queue")).To(
+					MatchKeys(IgnoreExtras, Keys{
+						"fifo_queue":            BeFalse(),
+						"deduplication_scope":   Equal("queue"),
+						"fifo_throughput_limit": Equal("perQueue"),
+					}),
+				)
+			})
+		})
+	})
+
 	Context("with DLQ enabled", func() {
 		BeforeAll(func() {
 			dlqARN := "arn:aws:sqs:us-west-2:123456789012:dlq"


### PR DESCRIPTION
[#187061563](https://www.pivotaltracker.com/story/show/187061563)

Related PRs:
- https://github.com/cloudfoundry/csb-brokerpak-aws/pull/1600

By adding this test, if such validation ever gets implemented in the provider we'll know it since the test will start failing as happened for:
https://github.com/cloudfoundry/csb-brokerpak-aws/pull/1597

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you ran `make run-integration-tests`?
* [x]  Have you ran `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

