### PR TITLE
fix: allow null values for iops

### DIFF
--- a/aws-mysql.yml
+++ b/aws-mysql.yml
@@ -54,6 +54,7 @@ provision:
       or "io1" (provisioned IOPS SSD).
     default: "io1"
   - field_name: iops
+    nullable: true
     type: integer
     details: |
       The amount of provisioned IOPS. For this property to take effect, `storage_type` must be

--- a/aws-postgresql.yml
+++ b/aws-postgresql.yml
@@ -54,6 +54,7 @@ provision:
     default: "io1"
   - field_name: iops
     type: integer
+    nullable: true
     details: |
       The amount of provisioned IOPS. For this property to take effect, `storage_type` must be
       set to `io1` or `gp3`.

--- a/integration-tests/mysql_test.go
+++ b/integration-tests/mysql_test.go
@@ -253,6 +253,23 @@ var _ = Describe("MySQL", Label("MySQL"), func() {
 				),
 			)
 		})
+
+		Context("should allow null values", func() {
+			It("iops", func() {
+				_, err := broker.Provision(mySQLServiceName, mySQLCustomPlanName, map[string]any{
+					"storage_type": "gp3",
+					"iops":         nil,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(mockTerraform.FirstTerraformInvocationVars()).To(
+					SatisfyAll(
+						HaveKeyWithValue("iops", BeNil()),
+						HaveKeyWithValue("storage_type", "gp3"),
+					),
+				)
+			})
+		})
 	})
 
 	Describe("updating instance", func() {

--- a/integration-tests/postgresql_test.go
+++ b/integration-tests/postgresql_test.go
@@ -258,6 +258,24 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 				),
 			)
 		})
+
+		Context("should allow null values", func() {
+			It("iops", func() {
+				_, err := broker.Provision(postgreSQLServiceName, "custom-sample", map[string]any{
+					"storage_type": "gp3",
+					"iops":         nil,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(mockTerraform.FirstTerraformInvocationVars()).To(
+					SatisfyAll(
+						HaveKeyWithValue("iops", BeNil()),
+						HaveKeyWithValue("storage_type", "gp3"),
+					),
+				)
+			})
+		})
+
 	})
 
 	Describe("updating instance", func() {


### PR DESCRIPTION
When creating rds instances an iops value of 0 is interpreted by downstream services as null value. However when updating this is not the case. Hence when trying to update a service where setting iops is not permitted by AWS, update operations error even when we are not trying to change the iops value. Allowing nulls for this property works as expected both for provisioning and update.

[#187149548](https://www.pivotaltracker.com/story/show/187149548)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

