### PR TITLE
chore: use more restrictive dependabot group patterns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   groups:
     aws-sdk-go-v2:
       patterns:
-        - "*aws-sdk-go-v2*"
+        - "github.com/aws/aws-sdk-go-v2/*"
 - package-ecosystem: gomod
   directory: "/acceptance-tests/apps/postgresqlapp"
   schedule:
@@ -22,7 +22,7 @@ updates:
   groups:
     aws-sdk-go-v2:
       patterns:
-        - "*aws-sdk-go-v2*"
+        - "github.com/aws/aws-sdk-go-v2/*"
 - package-ecosystem: gomod
   directory: "/acceptance-tests/apps/mysqlapp"
   schedule:
@@ -46,7 +46,7 @@ updates:
   groups:
     aws-sdk-go-v2:
       patterns:
-        - "*aws-sdk-go-v2*"
+        - "github.com/aws/aws-sdk-go-v2/*"
 - package-ecosystem: gomod
   directory: "/acceptance-tests/apps/dynamodbnsapp"
   schedule:
@@ -55,7 +55,7 @@ updates:
   groups:
     aws-sdk-go-v2:
       patterns:
-        - "*aws-sdk-go-v2*"
+        - "github.com/aws/aws-sdk-go-v2/*"
 - package-ecosystem: gomod
   directory: "/acceptance-tests/apps/sqsapp"
   schedule:
@@ -64,7 +64,7 @@ updates:
   groups:
     aws-sdk-go-v2:
       patterns:
-        - "*aws-sdk-go-v2*"
+        - "github.com/aws/aws-sdk-go-v2/*"
 - package-ecosystem: gomod
   directory: "/providers/terraform-provider-csbdynamodbns"
   schedule:
@@ -73,7 +73,7 @@ updates:
   groups:
     aws-sdk-go-v2:
       patterns:
-        - "*aws-sdk-go-v2*"
+        - "github.com/aws/aws-sdk-go-v2/*"
 - package-ecosystem: gomod
   directory: "/providers/terraform-provider-csbmajorengineversion/"
   schedule:
@@ -82,7 +82,7 @@ updates:
   groups:
     aws-sdk-go-v2:
       patterns:
-        - "*aws-sdk-go-v2*"
+        - "github.com/aws/aws-sdk-go-v2/*"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
The idea from this change came from the following slack thread: https://vmware.slack.com/archives/C5F98SBK8/p1709723670942369

Using a very permissive wildcard such as *aws-sdk-go-v2* could cause Dependabot to group version bumps for totally unrelated go modules/packages such as:
https://github.com/search?q=path%3Ago.mod+%28%22aws-sdk-go-v2%22+AND+NOT+%22github.com%2Faws%2Faws-sdk-go-v2%22%29&type=code

As of today, go.sum doesn't include any module named like that. However, new indirect dependencies can creep into our code which can match this wildcard.
Even in that scenario, I believe Dependabot doesn't bump indirect dependencies.

Still, I believe using more restrictive patterns is a better practice,  since it is easier to reason about and maybe a little bit safer.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

