### PR TITLE
chore: annotate sensitive terraform varaibles

### DIFF
--- a/terraform/aurora-mysql/bind/variables.tf
+++ b/terraform/aurora-mysql/bind/variables.tf
@@ -3,5 +3,8 @@ variable "reader_endpoint" { type = bool }
 variable "hostname" { type = string }
 variable "reader_hostname" { type = string }
 variable "admin_username" { type = string }
-variable "admin_password" { type = string }
+variable "admin_password" {
+  type      = string
+  sensitive = true
+}
 variable "port" { type = number }

--- a/terraform/aurora-postgresql/bind/variables.tf
+++ b/terraform/aurora-postgresql/bind/variables.tf
@@ -3,5 +3,8 @@ variable "reader_endpoint" { type = bool }
 variable "hostname" { type = string }
 variable "reader_hostname" { type = string }
 variable "admin_username" { type = string }
-variable "admin_password" { type = string }
+variable "admin_password" {
+  type      = string
+  sensitive = true
+}
 variable "port" { type = number }

--- a/terraform/mssql/bind/variables.tf
+++ b/terraform/mssql/bind/variables.tf
@@ -8,7 +8,8 @@ variable "admin_username" {
   type = string
 }
 variable "admin_password" {
-  type = string
+  type      = string
+  sensitive = true
 }
 variable "require_ssl" {
   type = bool

--- a/terraform/mysql/bind/variables.tf
+++ b/terraform/mysql/bind/variables.tf
@@ -15,7 +15,10 @@
 variable "db_name" { type = string }
 variable "hostname" { type = string }
 variable "admin_username" { type = string }
-variable "admin_password" { type = string }
+variable "admin_password" {
+  type      = string
+  sensitive = true
+}
 
 locals {
   port = 3306

--- a/terraform/postgresql/bind/variables.tf
+++ b/terraform/postgresql/bind/variables.tf
@@ -15,7 +15,10 @@
 variable "db_name" { type = string }
 variable "hostname" { type = string }
 variable "admin_username" { type = string }
-variable "admin_password" { type = string }
+variable "admin_password" {
+  type      = string
+  sensitive = true
+}
 variable "require_ssl" { type = bool }
 variable "provider_verify_certificate" { type = bool }
 


### PR DESCRIPTION
By annotating terraform variables that contain sensitive information, we ensure that they are not printed out in error messages.

[#183474478](https://www.pivotaltracker.com/story/show/183474478)
