### PR TITLE
feat: SQS allow sqs_managed_sse_enabled to be disabled

### DIFF
--- a/aws-sqs.yml
+++ b/aws-sqs.yml
@@ -97,13 +97,13 @@ provision:
         If not defined for a FIFO queue it defaults to `perQueue`.
     - field_name: sqs_managed_sse_enabled
       type: boolean
-      details: Enable SQS-managed encryption keys for encrypting messages.
+      details: Enable SQS-managed encryption keys for encrypting messages. Overridden by `kms_master_key_id`.
       default: true
     - field_name: kms_master_key_id
       type: string
       details: | 
         Specify the AWS KMS customer master key (CMK) for encryption.
-        The `sqs_managed_sse_enabled` property must be set to `false` if a KMS master key ID is provided.
+        Overrides the `sqs_managed_sse_enabled` property.
       default: ""
     - field_name: kms_data_key_reuse_period_seconds
       type: integer

--- a/terraform/sqs/provision/main.tf
+++ b/terraform/sqs/provision/main.tf
@@ -20,7 +20,7 @@ resource "aws_sqs_queue" "queue" {
   kms_master_key_id                 = var.kms_master_key_id == "" ? null : var.kms_master_key_id
   kms_data_key_reuse_period_seconds = var.kms_data_key_reuse_period_seconds
 
-  sqs_managed_sse_enabled = !var.sqs_managed_sse_enabled ? null : var.sqs_managed_sse_enabled
+  sqs_managed_sse_enabled = var.kms_master_key_id != "" ? null : var.sqs_managed_sse_enabled
 
   lifecycle {
     prevent_destroy = true


### PR DESCRIPTION
Allows the "sqs_managed_sse_enabled" to be disabled on a queue, while retaining the default of being enabled.

When "kms_master_key_id" is set, it will have the effect of unsetting "sqs_managed_sse_enabled", rather than failing with a conflict. This is to make the experience of setting "kms_master_key_id" more user-friendly.

[#187061621](https://www.pivotaltracker.com/story/show/187061621)
