### PR TITLE
fix: S3 - Add dependency on aws_s3_bucket_public_access_block to reduce flakiness on provision

### DIFF
--- a/terraform/s3/provision/main.tf
+++ b/terraform/s3/provision/main.tf
@@ -46,6 +46,8 @@ resource "aws_s3_bucket_ownership_controls" "bucket_ownership_controls" {
   rule {
     object_ownership = var.boc_object_ownership
   }
+
+  depends_on = [aws_s3_bucket_public_access_block.bucket_public_access_block]
 }
 
 resource "aws_s3_bucket_public_access_block" "bucket_public_access_block" {


### PR DESCRIPTION
We have seen issues with the S3 provioning failing at timesbeccasue of bucket ACL issues. There are a few aticles refering to changes to the AWS provider that point out that the `s3_bucket_public_access_block` should be the first one to be created. 

See links: [1](https://github.com/hashicorp/terraform-provider-aws/issues/30951#issuecomment-1523376909) and [2](https://stackoverflow.com/questions/76419099/access-denied-when-creating-s3-bucket-acl-s3-policy-using-terraform)

[#187284776](https://www.pivotaltracker.com/story/show/187284776)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

