### PR TITLE
fix: Add terraform provider replacement to handle opentofu registry p…

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -9,7 +9,11 @@ platforms:
 # - os: darwin
 #   arch: amd64
 terraform_state_provider_replacements:
+  registry.opentofu.org/hashicorp/aws: "registry.terraform.io/hashicorp/aws"
+  registry.opentofu.org/hashicorp/random: "registry.terraform.io/hashicorp/random"
+  registry.opentofu.org/cloud-service-broker/csbpg: "cloudfoundry.org/cloud-service-broker/csbpg"
   registry.terraform.io/cloud-service-broker/csbpg: "cloudfoundry.org/cloud-service-broker/csbpg"
+  registry.opentofu.org/cloud-service-broker/csbmysql: "cloudfoundry.org/cloud-service-broker/csbmysql"
   registry.terraform.io/cloud-service-broker/csbmysql: "cloudfoundry.org/cloud-service-broker/csbmysql"
 terraform_upgrade_path:
 - version: 1.6.2


### PR DESCRIPTION
…rovideres

Brokerpak v1.12.0 was build with an old version of the broker which used to put the providers in the opentofu registry path. Since these providers are taken from terraform we want to make sure that they are installed in the terraform registry path.
 This change makes sure that any state created with the previous version can continue to work with provideres being installed in the terraform path.

[#187439534](https://www.pivotaltracker.com/story/show/187439534)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

