### PR TITLE
test: don't import CSB as a library

### DIFF
--- a/providers/terraform-provider-csbdynamodbns/go.mod
+++ b/providers/terraform-provider-csbdynamodbns/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.11
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.31.1
 	github.com/aws/smithy-go v1.20.2
-	github.com/cloudfoundry/cloud-service-broker/v2 v2.0.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.8.1
 	github.com/onsi/ginkgo/v2 v2.17.1

--- a/providers/terraform-provider-csbdynamodbns/go.sum
+++ b/providers/terraform-provider-csbdynamodbns/go.sum
@@ -45,8 +45,6 @@ github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZ
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
-github.com/cloudfoundry/cloud-service-broker/v2 v2.0.0 h1:oUj1EUgZ8a29cLPJmVNN7l4TPEgaN7GGTUzbnLS/3ew=
-github.com/cloudfoundry/cloud-service-broker/v2 v2.0.0/go.mod h1:oCHQv6lC0gI2ADx8iRHJ4vOG6ORqO3mN/i8sDDLEH30=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=

--- a/providers/terraform-provider-csbdynamodbns/resource_dynamodb_instance_test.go
+++ b/providers/terraform-provider-csbdynamodbns/resource_dynamodb_instance_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/cloudfoundry/cloud-service-broker/v2/utils/freeport"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -25,7 +24,7 @@ var _ = Describe("Resource dynamodbns_instance", func() {
 	BeforeEach(func() {
 		var err error
 
-		port = freeport.Must()
+		port = freePort()
 		localDynamoDBURL = fmt.Sprintf("http://127.0.0.1:%d", port)
 		prefix = fmt.Sprintf("csb-%s-", uuid.New())
 

--- a/providers/terraform-provider-csbdynamodbns/terraform_provider_dynamodbns_suite_test.go
+++ b/providers/terraform-provider-csbdynamodbns/terraform_provider_dynamodbns_suite_test.go
@@ -1,6 +1,7 @@
 package main_test
 
 import (
+	"net"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -10,4 +11,14 @@ import (
 func TestTerraformProviderDynamodbns(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "TerraformProviderDynamodbns Suite")
+}
+
+func freePort() int {
+	GinkgoHelper()
+
+	listener, err := net.Listen("tcp", "localhost:0")
+	Expect(err).NotTo(HaveOccurred())
+
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port
 }


### PR DESCRIPTION
A test was importing the cloud-service-broker app as a library. This has the downsides of:
- potentially breaking when internals of the app are changed
- creating an additional thing that needs updating

Since the imported function just requires a few lines of code, it's better to just duplicate the required function.

[#187499320](https://www.pivotaltracker.com/story/show/187499320)