### PR TITLE
fix: invalid s3:DeleteReplicationConfiguration policy

### DIFF
--- a/terraform/s3/bind/data.tf
+++ b/terraform/s3/bind/data.tf
@@ -46,7 +46,6 @@ data "aws_iam_policy_document" "user_policy" {
       "s3:PutLifecycleConfiguration",
       "s3:PutReplicationConfiguration",
       "s3:GetReplicationConfiguration",
-      "s3:DeleteReplicationConfiguration",
     ]
     resources = [
       var.arn


### PR DESCRIPTION
The permissions are now included in s3:PutReplicationConfiguration action.

See AWS docs: https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketReplication.html

[#187476643](https://www.pivotaltracker.com/story/show/187476643)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

