### PR TITLE
test: detect tile-pushed brokers

### DIFF
--- a/acceptance-tests/helpers/brokers/default.go
+++ b/acceptance-tests/helpers/brokers/default.go
@@ -20,18 +20,13 @@ func DefaultBrokerName() string {
 		Names []string `jsonry:"resources.name"`
 	}
 	out, _ := cf.Run("curl", "/v3/service_brokers")
-	Expect(jsonry.Unmarshal([]byte(out), &receiver)).NotTo(HaveOccurred())
+	Expect(jsonry.Unmarshal([]byte(out), &receiver)).To(Succeed())
 
-	username := os.Getenv("USER")
-	for _, n := range receiver.Names {
-		if n == "broker-cf-test" {
-			defaultBrokerName = n
-			return n
-		}
-
-		if username != "" && n == fmt.Sprintf("csb-%s", username) {
-			defaultBrokerName = n
-			return n
+	for _, brokerName := range receiver.Names {
+		switch brokerName {
+		case fmt.Sprintf("csb-%s", os.Getenv("USER")), "broker-cf-test", "cloud-service-broker-aws":
+			defaultBrokerName = brokerName
+			return brokerName
 		}
 	}
 


### PR DESCRIPTION
We want to run tests against the tile, so it's helpful if the tests can find the broker pushed by the tile.

[#187498188](https://www.pivotaltracker.com/story/show/187498188)