### PR TITLE
test: correct plan name

### DIFF
--- a/acceptance-tests/upgrade/update_and_upgrade_mysql_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mysql_test.go
@@ -25,7 +25,7 @@ var _ = Describe("UpgradeMySQLTest", Label("mysql", "upgrade"), func() {
 			By("creating a service")
 			serviceInstance := services.CreateInstance(
 				"csb-aws-mysql",
-				services.WithPlan("small"),
+				services.WithPlan("default"),
 				services.WithBroker(serviceBroker),
 			)
 			defer serviceInstance.Delete()


### PR DESCRIPTION
In a previous commit, the MySQL upgrade test was changed to no longer use a custom plan. This commit updates the plan name to match the one that is available once the custom plan has been removed.

