### PR TITLE
chore: Revert bumping tf aws provider until we consume latest bosh go release

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -23,8 +23,8 @@ terraform_binaries:
   source: https://github.com/opentofu/opentofu/archive/v1.8.1.zip
   default: true
 - name: terraform-provider-aws
-  version: 5.65.0
-  source: https://github.com/terraform-providers/terraform-provider-aws/archive/v5.65.0.zip
+  version: 5.64.0
+  source: https://github.com/terraform-providers/terraform-provider-aws/archive/v5.64.0.zip
 - name: terraform-provider-random
   version: 3.6.2
   source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.6.2.zip


### PR DESCRIPTION
### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

