### PR TITLE
feat: Enable passing admin username for Postgres

### DIFF
--- a/aws-postgresql.yml
+++ b/aws-postgresql.yml
@@ -330,6 +330,11 @@ provision:
       If you do, the encryption is done using an AWS KMS customer managed key.
       This property if provided, will set the customer managed key to use for encrypting the Cloudwatch log group
       created for the RDS PostgreSQL and upgrade logs.
+  - field_name: admin_username
+    type: string
+    details: The username to use for the admin user of the database. When not specified a random username will be generated. This property should only be used when migrating data.
+    default: ""
+    prohibit_update: true
   computed_inputs:
   - name: labels
     default: ${json.marshal(request.default_labels)}

--- a/integration-tests/postgresql_test.go
+++ b/integration-tests/postgresql_test.go
@@ -214,6 +214,7 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 				"enable_export_upgrade_logs":                        true,
 				"cloudwatch_upgrade_log_group_retention_in_days":    1,
 				"cloudwatch_log_groups_kms_key_id":                  "arn:aws:kms:us-west-2:xxxxxxxxxxxx:key/xxxxxxxx-80b9-4afd-98c0-xxxxxxxxxxxx",
+				"admin_username":                                    "some-other-username",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -255,6 +256,7 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 					HaveKeyWithValue("enable_export_upgrade_logs", true),
 					HaveKeyWithValue("cloudwatch_upgrade_log_group_retention_in_days", BeNumerically("==", 1)),
 					HaveKeyWithValue("cloudwatch_log_groups_kms_key_id", "arn:aws:kms:us-west-2:xxxxxxxxxxxx:key/xxxxxxxx-80b9-4afd-98c0-xxxxxxxxxxxx"),
+					HaveKeyWithValue("admin_username", "some-other-username"),
 				),
 			)
 		})
@@ -301,6 +303,7 @@ var _ = Describe("Postgresql", Label("Postgresql"), func() {
 				const initialProvisionInvocation = 1
 				Expect(mockTerraform.ApplyInvocations()).To(HaveLen(initialProvisionInvocation))
 			},
+			Entry("admin_username", "admin_username", "new-username"),
 			Entry("update region", "region", "no-matter-what-region"),
 			Entry("update kms_key_id", "kms_key_id", "no-matter-what-key"),
 			Entry("update db_name", "db_name", "no-matter-what-name"),

--- a/terraform/postgresql/provision/main.tf
+++ b/terraform/postgresql/provision/main.tf
@@ -38,6 +38,7 @@ resource "random_string" "username" {
   length  = 16
   special = false
   numeric = false
+  count   = length(var.admin_username) == 0 ? 1 : 0
 }
 
 resource "random_password" "password" {
@@ -57,7 +58,7 @@ resource "aws_db_instance" "db_instance" {
   instance_class                        = local.instance_class
   identifier                            = var.instance_name
   db_name                               = var.db_name
-  username                              = random_string.username.result
+  username                              = length(var.admin_username) == 0 ? random_string.username[0].result : var.admin_username
   password                              = random_password.password.result
   parameter_group_name                  = length(var.parameter_group_name) == 0 ? aws_db_parameter_group.db_parameter_group[0].name : var.parameter_group_name
   tags                                  = var.labels

--- a/terraform/postgresql/provision/variables.tf
+++ b/terraform/postgresql/provision/variables.tf
@@ -64,3 +64,4 @@ variable "enable_export_upgrade_logs" { type = bool }
 variable "cloudwatch_postgresql_log_group_retention_in_days" { type = number }
 variable "cloudwatch_upgrade_log_group_retention_in_days" { type = number }
 variable "cloudwatch_log_groups_kms_key_id" { type = string }
+variable "admin_username" { type = string }


### PR DESCRIPTION
Similar to MySQL this is required in order to be able to migrate instances from the legacy broker to CSB

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

