### PR TITLE
chore: build the right thing on M-series Mac

### DIFF
--- a/providers/terraform-provider-csbdynamodbns/Makefile
+++ b/providers/terraform-provider-csbdynamodbns/Makefile
@@ -20,8 +20,9 @@ build: download checkfmt checkimports vet ../build/cloudfoundry.org ## build the
 ../build/cloudfoundry.org: *.go */*.go
 	mkdir -p ../build/cloudfoundry.org/cloud-service-broker/csbdynamodbns/$(VERSION)/linux_amd64
 	mkdir -p ../build/cloudfoundry.org/cloud-service-broker/csbdynamodbns/$(VERSION)/darwin_amd64
-	CGO_ENABLED=0 GOOS=linux $(GO) build -o ../build/cloudfoundry.org/cloud-service-broker/csbdynamodbns/$(VERSION)/linux_amd64/terraform-provider-csbdynamodbns_v$(VERSION)
-	CGO_ENABLED=0 GOOS=darwin $(GO) build -o ../build/cloudfoundry.org/cloud-service-broker/csbdynamodbns/$(VERSION)/darwin_amd64/terraform-provider-csbdynamodbns_v$(VERSION)
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build -o ../build/cloudfoundry.org/cloud-service-broker/csbdynamodbns/$(VERSION)/linux_amd64/terraform-provider-csbdynamodbns_v$(VERSION)
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GO) build -o ../build/cloudfoundry.org/cloud-service-broker/csbdynamodbns/$(VERSION)/darwin_amd64/terraform-provider-csbdynamodbns_v$(VERSION)
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GO) build -o ../build/cloudfoundry.org/cloud-service-broker/csbdynamodbns/$(VERSION)/darwin_arm64/terraform-provider-csbdynamodbns_v$(VERSION)
 
 .PHONY: clean
 clean: ## clean up build artifacts

--- a/providers/terraform-provider-csbmajorengineversion/Makefile
+++ b/providers/terraform-provider-csbmajorengineversion/Makefile
@@ -20,8 +20,9 @@ build: download checkfmt checkimports vet build_binaries_in_cloudfoundry_namespa
 build_binaries_in_cloudfoundry_namespace:
 	mkdir -p ../build/cloudfoundry.org/cloud-service-broker/csbmajorengineversion/$(VERSION)/linux_amd64
 	mkdir -p ../build/cloudfoundry.org/cloud-service-broker/csbmajorengineversion/$(VERSION)/darwin_amd64
-	CGO_ENABLED=0 GOOS=linux $(GO) build -o ../build/cloudfoundry.org/cloud-service-broker/csbmajorengineversion/$(VERSION)/linux_amd64/terraform-provider-csbmajorengineversion_v$(VERSION)
-	CGO_ENABLED=0 GOOS=darwin $(GO) build -o ../build/cloudfoundry.org/cloud-service-broker/csbmajorengineversion/$(VERSION)/darwin_amd64/terraform-provider-csbmajorengineversion_v$(VERSION)
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build -o ../build/cloudfoundry.org/cloud-service-broker/csbmajorengineversion/$(VERSION)/linux_amd64/terraform-provider-csbmajorengineversion_v$(VERSION)
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GO) build -o ../build/cloudfoundry.org/cloud-service-broker/csbmajorengineversion/$(VERSION)/darwin_amd64/terraform-provider-csbmajorengineversion_v$(VERSION)
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(GO) build -o ../build/cloudfoundry.org/cloud-service-broker/csbmajorengineversion/$(VERSION)/darwin_arm64/terraform-provider-csbmajorengineversion_v$(VERSION)
 
 .PHONY: clean
 clean: ## clean up build artifacts


### PR DESCRIPTION
GOARCH will default to arm64 rather than amd64

