### PR TITLE
test: at_rest_encryption_enabled is a NullableBool

### DIFF
--- a/terraform-tests/redis_test.go
+++ b/terraform-tests/redis_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Redis", Label("redis-terraform"), Ordered, func() {
 					"transit_encryption_enabled":  BeTrue(),
 					"automatic_failover_enabled":  BeTrue(),
 					"apply_immediately":           BeTrue(),
-					"at_rest_encryption_enabled":  BeTrue(),
+					"at_rest_encryption_enabled":  Equal("true"),
 					"kms_key_id":                  Equal("fake-encryption-at-rest-key"),
 					"snapshot_retention_limit":    BeNumerically("==", 12),
 					"final_snapshot_identifier":   Equal("tortoise"),


### PR DESCRIPTION
The underneath type of nullable boolean is a string

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

