### PR TITLE
docs: use ca_cert instead of ca_cert_file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,7 +56,7 @@ thus keeping them private to the application (they won't show up in `cf env app_
 | CH_UAA_CLIENT_NAME     | credhub.uaa_client_name     | string  | uaa username - usually `credhub_admin_client`                                                               |
 | CH_UAA_CLIENT_SECRET   | credhub.uaa_client_secret   | string  | uaa client secret - "*Credhub Admin Client Credentials*" from *Operations Manager > PAS > Credentials* tab. |
 | CH_SKIP_SSL_VALIDATION | credhub.skip_ssl_validation | boolean | skip SSL validation if true                                                                                 |
-| CH_CA_CERT_FILE        | credhub.ca_cert_file        | path    | path to cert file                                                                                           |
+| CH_CA_CERT             | credhub.ca_cert             | string  | CA cert                                                                                                     |
 
 ## Brokerpak Configuration
 


### PR DESCRIPTION
### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

