### PR TITLE
chore: Fixes broker 'failed to allocate' test errors

### DIFF
--- a/acceptance-tests/helpers/services/delete.go
+++ b/acceptance-tests/helpers/services/delete.go
@@ -10,11 +10,15 @@ import (
 )
 
 func (s *ServiceInstance) Delete() {
+	Delete(s.Name)
+}
+
+func Delete(name string) {
 	switch cf.Version() {
 	case cf.VersionV8:
-		deleteWithWait(s.Name)
+		deleteWithWait(name)
 	default:
-		deleteWithPoll(s.Name)
+		deleteWithPoll(name)
 	}
 }
 

--- a/acceptance-tests/upgrade/update_and_upgrade_aurora_postgresql_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_aurora_postgresql_test.go
@@ -23,9 +23,17 @@ var _ = Describe("UpgradeAuroraPostgreSQLTest", Label("aurora-postgresql", "upgr
 			defer serviceBroker.Delete()
 
 			By("creating a service")
+			serviceOffering := "csb-aws-aurora-postgresql"
+			servicePlan := "default"
+			serviceName := random.Name(random.WithPrefix(serviceOffering, servicePlan))
+			// CreateInstance can fail and can leave a service record (albeit a failed one) lying around.
+			// We can't delete service brokers that have serviceInstances, so we need to ensure the service instance
+			// is cleaned up regardless as to whether it wa successful. This is important when we use our own service broker
+			// (which can only have 5 instances at any time) to prevent subsequent test failures.
+			defer services.Delete(serviceName)
 			serviceInstance := services.CreateInstance(
-				"csb-aws-aurora-postgresql",
-				services.WithPlan("default"),
+				serviceOffering,
+				services.WithPlan(servicePlan),
 				services.WithParameters(
 					map[string]any{
 						"engine_version":          "13",
@@ -35,8 +43,8 @@ var _ = Describe("UpgradeAuroraPostgreSQLTest", Label("aurora-postgresql", "upgr
 						"instance_class":          "db.serverless",
 					}),
 				services.WithBroker(serviceBroker),
+				services.WithName(serviceName),
 			)
-			defer serviceInstance.Delete()
 
 			By("pushing the unstarted app twice")
 			appOne := apps.Push(apps.WithApp(apps.PostgreSQL))
@@ -67,7 +75,7 @@ var _ = Describe("UpgradeAuroraPostgreSQLTest", Label("aurora-postgresql", "upgr
 			serviceBroker.UpdateBroker(developmentBuildDir)
 
 			By("validating that the instance plan is still active")
-			Expect(plans.ExistsAndAvailable("default", "csb-aws-aurora-postgresql", serviceBroker.Name))
+			Expect(plans.ExistsAndAvailable(servicePlan, serviceOffering, serviceBroker.Name))
 
 			By("upgrading service instance")
 			serviceInstance.Upgrade()

--- a/acceptance-tests/upgrade/update_and_upgrade_postgresql_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_postgresql_test.go
@@ -31,12 +31,20 @@ var _ = Describe("UpgradePostgreSQLTest", Label("postgresql", "upgrade"), func()
 			defer serviceBroker.Delete()
 
 			By("creating a service")
+			serviceOffering := "csb-aws-postgresql"
+			servicePlan := "default_postgres_version13"
+			serviceName := random.Name(random.WithPrefix(serviceOffering, servicePlan))
+			// CreateInstance can fail and can leave a service record (albeit a failed one) lying around.
+			// We can't delete service brokers that have serviceInstances, so we need to ensure the service instance
+			// is cleaned up regardless as to whether it wa successful. This is important when we use our own service broker
+			// (which can only have 5 instances at any time) to prevent subsequent test failures.
+			defer services.Delete(serviceName)
 			serviceInstance := services.CreateInstance(
-				"csb-aws-postgresql",
-				services.WithPlan("default_postgres_version13"),
+				serviceOffering,
+				services.WithPlan(servicePlan),
 				services.WithBroker(serviceBroker),
+				services.WithName(serviceName),
 			)
-			defer serviceInstance.Delete()
 
 			By("pushing the unstarted app twice")
 			appOne := apps.Push(apps.WithApp(apps.PostgreSQL))
@@ -67,7 +75,7 @@ var _ = Describe("UpgradePostgreSQLTest", Label("postgresql", "upgrade"), func()
 			serviceBroker.UpdateBroker(developmentBuildDir, customPlans)
 
 			By("validating that the instance plan is still active")
-			Expect(plans.ExistsAndAvailable("default_postgres_version13", "csb-aws-postgresql", serviceBroker.Name))
+			Expect(plans.ExistsAndAvailable(servicePlan, serviceOffering, serviceBroker.Name))
 
 			By("upgrading service instance")
 			serviceInstance.Upgrade()

--- a/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_redis_test.go
@@ -23,13 +23,21 @@ var _ = Describe("Redis", Label("redis"), func() {
 			defer serviceBroker.Delete()
 
 			By("creating a service instance")
+			serviceOffering := "csb-aws-redis"
+			servicePlan := "example-with-flexible-node-type"
+			serviceName := random.Name(random.WithPrefix(serviceOffering, servicePlan))
+			// CreateInstance can fail and can leave a service record (albeit a failed one) lying around.
+			// We can't delete service brokers that have serviceInstances, so we need to ensure the service instance
+			// is cleaned up regardless as to whether it wa successful. This is important when we use our own service broker
+			// (which can only have 5 instances at any time) to prevent subsequent test failures.
+			defer services.Delete(serviceName)
 			serviceInstance := services.CreateInstance(
-				"csb-aws-redis",
-				services.WithPlan("example-with-flexible-node-type"),
+				serviceOffering,
+				services.WithPlan(servicePlan),
 				services.WithParameters(map[string]any{"node_type": "cache.t3.medium"}),
 				services.WithBroker(serviceBroker),
+				services.WithName(serviceName),
 			)
-			defer serviceInstance.Delete()
 
 			By("pushing the unstarted app twice")
 			appOne := apps.Push(apps.WithApp(apps.Redis))
@@ -55,7 +63,7 @@ var _ = Describe("Redis", Label("redis"), func() {
 			serviceBroker.UpdateBroker(developmentBuildDir)
 
 			By("validating that the instance plan is still active")
-			Expect(plans.ExistsAndAvailable("example-with-flexible-node-type", "csb-aws-redis", serviceBroker.Name))
+			Expect(plans.ExistsAndAvailable(servicePlan, serviceOffering, serviceBroker.Name))
 
 			By("upgrading service instance")
 			serviceInstance.Upgrade()

--- a/acceptance-tests/upgrade/update_and_upgrade_s3_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_s3_test.go
@@ -23,12 +23,20 @@ var _ = Describe("UpgradeS3Test", Label("upgrade", "s3"), func() {
 			defer serviceBroker.Delete()
 
 			By("creating a service")
+			serviceOffering := "csb-aws-s3-bucket"
+			servicePlan := "default"
+			serviceName := random.Name(random.WithPrefix(serviceOffering, servicePlan))
+			// CreateInstance can fail and can leave a service record (albeit a failed one) lying around.
+			// We can't delete service brokers that have serviceInstances, so we need to ensure the service instance
+			// is cleaned up regardless as to whether it wa successful. This is important when we use our own service broker
+			// (which can only have 5 instances at any time) to prevent subsequent test failures.
+			defer services.Delete(serviceName)
 			serviceInstance := services.CreateInstance(
-				"csb-aws-s3-bucket",
-				services.WithPlan("default"),
+				serviceOffering,
+				services.WithPlan(servicePlan),
 				services.WithBroker(serviceBroker),
+				services.WithName(serviceName),
 			)
-			defer serviceInstance.Delete()
 
 			By("pushing the unstarted app twice")
 			appOne := apps.Push(apps.WithApp(apps.S3))
@@ -53,7 +61,7 @@ var _ = Describe("UpgradeS3Test", Label("upgrade", "s3"), func() {
 			serviceBroker.UpdateBroker(developmentBuildDir)
 
 			By("validating that the instance plan is still active")
-			Expect(plans.ExistsAndAvailable("default", "csb-aws-s3-bucket", serviceBroker.Name))
+			Expect(plans.ExistsAndAvailable(servicePlan, serviceOffering, serviceBroker.Name))
 
 			By("upgrading the service instance")
 			serviceInstance.Upgrade()

--- a/acceptance-tests/withoutcredhub_test.go
+++ b/acceptance-tests/withoutcredhub_test.go
@@ -23,12 +23,20 @@ var _ = Describe("Without CredHub", Label("withoutcredhub"), func() {
 		defer broker.Delete()
 
 		By("creating a service instance")
+		serviceOffering := "csb-aws-s3-bucket"
+		servicePlan := "default"
+		serviceName := random.Name(random.WithPrefix(serviceOffering, servicePlan))
+		// CreateInstance can fail and can leave a service record (albeit a failed one) lying around.
+		// We can't delete service brokers that have serviceInstances, so we need to ensure the service instance
+		// is cleaned up regardless as to whether it wa successful. This is important when we use our own service broker
+		// (which can only have 5 instances at any time) to prevent subsequent test failures.
+		defer services.Delete(serviceName)
 		serviceInstance := services.CreateInstance(
-			"csb-aws-s3-bucket",
-			services.WithPlan("default"),
+			serviceOffering,
+			services.WithPlan(servicePlan),
 			services.WithBroker(broker),
+			services.WithName(serviceName),
 		)
-		defer serviceInstance.Delete()
 
 		By("pushing the unstarted app")
 		app := apps.Push(apps.WithApp(apps.S3))


### PR DESCRIPTION
We can only have 5 instances of our test broker running. Tests that use the test broker can see 'failed to allocate' errors. This is because in the case of a failed creation of a service in our tests will fail to clean up the test broker, causing other test runs to fail.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

