### PR TITLE
chore: Fixed failing AWS SQS terraform test.

### DIFF
--- a/terraform-tests/sqs_test.go
+++ b/terraform-tests/sqs_test.go
@@ -69,17 +69,16 @@ var _ = Describe("SQS", Label("SQS-terraform"), Ordered, func() {
 		It("should create an SQS queue with the correct properties", func() {
 			Expect(AfterValuesForType(plan, "aws_sqs_queue")).To(
 				MatchKeys(IgnoreExtras, Keys{
-					"name":                              Equal(name),
-					"fifo_queue":                        BeFalse(),
-					"visibility_timeout_seconds":        BeNumerically("==", 30),
-					"message_retention_seconds":         BeNumerically("==", 345600),
-					"max_message_size":                  BeNumerically("==", 262144),
-					"delay_seconds":                     BeZero(),
-					"receive_wait_time_seconds":         BeZero(),
-					"kms_master_key_id":                 BeNil(),
-					"kms_data_key_reuse_period_seconds": BeNumerically("==", 300),
-					"content_based_deduplication":       BeFalse(),
-					"sqs_managed_sse_enabled":           BeTrue(),
+					"name":                        Equal(name),
+					"fifo_queue":                  BeFalse(),
+					"visibility_timeout_seconds":  BeNumerically("==", 30),
+					"message_retention_seconds":   BeNumerically("==", 345600),
+					"max_message_size":            BeNumerically("==", 262144),
+					"delay_seconds":               BeZero(),
+					"receive_wait_time_seconds":   BeZero(),
+					"kms_master_key_id":           BeNil(),
+					"content_based_deduplication": BeFalse(),
+					"sqs_managed_sse_enabled":     BeTrue(),
 					"tags_all": MatchAllKeys(Keys{
 						"label1": Equal("value1"),
 					}),


### PR DESCRIPTION
AWS has changed behaviour to return zero for kms_data_key_reuse_period_seconds unless kms_master_key_id is set. Because of the limitation of how we wire up our brokerpaks with terraform vars, this parameter has to be set and set to a valid value - but AWS willnow return 0 for unless kms_master_key_id is set.

This change corrects the test to match current behaviour.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

