### PR TITLE
test: restore MS-SQL DB to MS-SQL security group

### DIFF
--- a/acceptance-tests/mssql_test.go
+++ b/acceptance-tests/mssql_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -348,7 +349,7 @@ func vpcSecurityGroupIDs(vpcID string) []string {
 
 	var ids []string
 	for _, sg := range receiver.SecurityGroups {
-		if sg.GroupName != "default" {
+		if strings.HasPrefix(sg.GroupName, "csb-mssql-") {
 			ids = append(ids, sg.GroupID)
 		}
 	}


### PR DESCRIPTION
Code previously could have added in MySQL security groups, which caused interference between tests