### PR TITLE
feat: allow s3 objects to be tagged

### DIFF
--- a/terraform/s3/bind/data.tf
+++ b/terraform/s3/bind/data.tf
@@ -55,19 +55,22 @@ data "aws_iam_policy_document" "user_policy" {
   statement {
     sid = "bucketContentAccess"
     actions = [
-      "s3:GetObject",
-      "s3:GetObjectVersion",
-      "s3:PutObject",
-      "s3:GetObjectAcl",
-      "s3:GetObjectVersionAcl",
-      "s3:PutObjectAcl",
-      "s3:PutObjectVersionAcl",
-      "s3:DeleteObject",
-      "s3:DeleteObjectVersion",
-      "s3:ListMultipartUploadParts",
       "s3:AbortMultipartUpload",
+      "s3:DeleteObject",
+      "s3:DeleteObjectTagging",
+      "s3:DeleteObjectVersion",
+      "s3:GetObject",
+      "s3:GetObjectAcl",
+      "s3:GetObjectTagging",
       "s3:GetObjectTorrent",
+      "s3:GetObjectVersion",
+      "s3:GetObjectVersionAcl",
       "s3:GetObjectVersionTorrent",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionAcl",
       "s3:RestoreObject",
     ]
     resources = [


### PR DESCRIPTION
The user for S3 bucket bindings will have the permission to tag objects within a bucket.

Behaviour verified manually. We don't add automated tests for every S3 behaviour.