### PR TITLE
chore: fix the cloud-service-broker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,14 +36,14 @@ BROKER_GO_OPTS=PORT=8080 \
 				GSB_COMPATIBILITY_ENABLE_BETA_SERVICES='$(GSB_COMPATIBILITY_ENABLE_BETA_SERVICES)'
 
 PAK_PATH=$(PWD)
-RUN_CSB=$(BROKER_GO_OPTS) go tool cloud-service-broker
+RUN_CSB=$(BROKER_GO_OPTS) go run github.com/cloudfoundry/cloud-service-broker/v2
 LDFLAGS="-X github.com/cloudfoundry/cloud-service-broker/v2/utils.Version=$(CSB_VERSION)"
 GET_CSB="env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags $(LDFLAGS) github.com/cloudfoundry/cloud-service-broker/v2"
 
 ###### Targets ################################################################
 
 .PHONY: build
-build: $(IAAS)-services-*.brokerpak ## build brokerpak
+build: cloud-service-broker $(IAAS)-services-*.brokerpak ## build brokerpak
 
 $(IAAS)-services-*.brokerpak: *.yml terraform/*/*/*.tf terraform/*/*/*/*.tf providers | $(PAK_BUILD_CACHE_PATH)
 	$(RUN_CSB) pak build

--- a/go.mod
+++ b/go.mod
@@ -147,7 +147,6 @@ require (
 )
 
 tool (
-	github.com/cloudfoundry/cloud-service-broker/v2
 	github.com/onsi/ginkgo/v2/ginkgo
 	golang.org/x/tools/cmd/goimports
 	honnef.co/go/tools/cmd/staticcheck

--- a/tool/tools.go
+++ b/tool/tools.go
@@ -1,0 +1,11 @@
+//go:build tools
+// +build tools
+
+package tools
+
+import (
+	_ "github.com/cloudfoundry/cloud-service-broker/v2"
+)
+
+// This file imports the Cloud Service Broker in order to pin the version
+// For other tools, use "go get -tool"


### PR DESCRIPTION
- The cloud-service-broker dependency was updated to be a Go 1.24 tool
- This did not work because you can't "go build" a tool, it it's been reverted
- Also "make build" will now build the cloud-service-broker too, as this is typically used as the litmus test of whether everything is working, and in this case we had a miss.

