### PR TITLE
test: wait for delete operation to propagate

### DIFF
--- a/acceptance-tests/mysql_test.go
+++ b/acceptance-tests/mysql_test.go
@@ -204,6 +204,9 @@ var _ = Describe("MySQL", Label("mysql"), func() {
 			return session.Err
 		}).WithPolling(time.Minute).WithTimeout(time.Hour).Should(gbytes.Say("not found"))
 
+		By("waiting a bit to avoid a 'DBInstanceAlreadyExists' error if we restore too soon")
+		time.Sleep(time.Minute)
+
 		// At the time of writing, there's no flag in the AWS CLI (or in the console) to enable AWS secrets manager when
 		// restoring from a snapshot. Ideally we could restore with the "--manage-master-user-password" and there would
 		// be no need to mess around with the settings after the restore, but that flag hasn't been added yet.

--- a/acceptance-tests/postgresql_test.go
+++ b/acceptance-tests/postgresql_test.go
@@ -162,6 +162,9 @@ var _ = Describe("PostgreSQL", Label("postgresql"), func() {
 			return session.Err
 		}).WithPolling(time.Minute).WithTimeout(time.Hour).Should(gbytes.Say("not found"))
 
+		By("waiting a bit to avoid a 'DBInstanceAlreadyExists' error if we restore too soon")
+		time.Sleep(time.Minute)
+
 		// At the time of writing, there's no flag in the AWS CLI (or in the console) to enable AWS secrets manager when
 		// restoring from a snapshot. Ideally we could restore with the "--manage-master-user-password" and there would
 		// be no need to mess around with the settings after the restore, but that flag hasn't been added yet.


### PR DESCRIPTION
- We have seen the MySQL restore test fail intermittently with a DBInstanceAlreadyExists error
- The MS-SQL test has a workaround for this: https://github.com/cloudfoundry/csb-brokerpak-aws/blob/b75da4d1e28b6c6aedec8e9b7960f0606c89babe/acceptance-tests/mssql_test.go#L281-L282
- Although not the most sophisticated workaround, it has been successful up to now, so the simplest improvement is to use the same workaround