### PR TITLE
chore: aurora postgres v17 is no longer available - test with v16

### DIFF
--- a/acceptance-tests/aurora_postgresql_test.go
+++ b/acceptance-tests/aurora_postgresql_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Aurora PostgreSQL", Label("aurora-postgresql"), func() {
 	})
 
 	It("works with the latest supported version of Postgres", Label("JDBC-p", "PostgresLatest"), func() {
-		testWithMultipleApps("17")
+		testWithMultipleApps("16")
 	})
 })
 


### PR DESCRIPTION
Aurora PG17 is no longer available. Updated test to test with v16.

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you ran `make run-integration-tests` and `make run-terraform-tests`?
* [ ] Have you ran acceptance tests for the service under change?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

