### PR TITLE
chore: update docs links

### DIFF
--- a/aws-aurora-mysql.yml
+++ b/aws-aurora-mysql.yml
@@ -4,7 +4,7 @@ id: 7446e75e-2a09-11ed-8816-23072dae39dc
 description: Amazon Aurora for MySQL
 display_name: Amazon Aurora for MySQL
 image_url: file://service-images/csb.png
-documentation_url: https://docs.vmware.com/en/Cloud-Service-Broker-for-VMware-Tanzu/index.html
+documentation_url: https://techdocs.broadcom.com/tnz-aws-broker-cf
 provider_display_name: VMware
 support_url: https://aws.amazon.com/rds/aurora/
 tags: [aws, aurora, mysql]

--- a/aws-aurora-postgresql.yml
+++ b/aws-aurora-postgresql.yml
@@ -4,7 +4,7 @@ id: 36203e40-2945-11ed-8980-eb81bd131a02
 description: Amazon Aurora for PostgreSQL
 display_name: Amazon Aurora for PostgreSQL
 image_url: file://service-images/csb.png
-documentation_url: https://docs.vmware.com/en/Cloud-Service-Broker-for-VMware-Tanzu/index.html
+documentation_url: https://techdocs.broadcom.com/tnz-aws-broker-cf
 provider_display_name: VMware
 support_url: https://aws.amazon.com/rds/aurora/
 tags: [aws, aurora, postgresql, postgres]

--- a/aws-dynamodb-namespace.yml
+++ b/aws-dynamodb-namespace.yml
@@ -18,7 +18,7 @@ id: 07d06aeb-f87a-4e06-90ae-0b07a8c21a02
 description: CSB Amazon DynamoDB Namespace
 display_name: CSB Amazon DynamoDB Namespace
 image_url: file://service-images/csb.png
-documentation_url: https://docs.vmware.com/en/Cloud-Service-Broker-for-VMware-Tanzu/index.html
+documentation_url: https://techdocs.broadcom.com/tnz-aws-broker-cf
 provider_display_name: VMware
 support_url: https://aws.amazon.com/dynamodb/
 tags: [aws, dynamodb, namespace]

--- a/aws-mssql.yml
+++ b/aws-mssql.yml
@@ -5,7 +5,7 @@ id: 8b17758e-37a9-4c1c-af84-971d4a5552c1
 description: CSB Amazon RDS for MSSQL
 display_name: CSB Amazon RDS for MSSQL
 image_url: file://service-images/csb.png
-documentation_url: https://docs.vmware.com/en/Cloud-Service-Broker-for-VMware-Tanzu/index.html
+documentation_url: https://techdocs.broadcom.com/tnz-aws-broker-cf
 provider_display_name: VMware
 support_url: https://aws.amazon.com/sql/
 tags: [aws, mssql]

--- a/aws-mysql.yml
+++ b/aws-mysql.yml
@@ -18,7 +18,7 @@ id: fa22af0f-3637-4a36-b8a7-cfc61168a3e0
 description: CSB Amazon RDS for MySQL
 display_name: CSB Amazon RDS for MySQL
 image_url: file://service-images/csb.png
-documentation_url: https://docs.vmware.com/en/Cloud-Service-Broker-for-VMware-Tanzu/index.html
+documentation_url: https://techdocs.broadcom.com/tnz-aws-broker-cf
 provider_display_name: VMware
 support_url: https://aws.amazon.com/rds/mysql/resources/?nc=sn&loc=5
 tags: [aws, mysql]

--- a/aws-postgresql.yml
+++ b/aws-postgresql.yml
@@ -18,7 +18,7 @@ id: fa6334bc-5314-4b63-8a74-c0e4b638c950
 description: CSB Amazon RDS for PostgreSQL
 display_name: CSB Amazon RDS for PostgreSQL
 image_url: file://service-images/csb.png
-documentation_url: https://docs.vmware.com/en/Cloud-Service-Broker-for-VMware-Tanzu/index.html
+documentation_url: https://techdocs.broadcom.com/tnz-aws-broker-cf
 provider_display_name: VMware
 support_url: https://aws.amazon.com/rds/postgresql/
 tags: [aws, postgresql, postgres]

--- a/aws-redis.yml
+++ b/aws-redis.yml
@@ -18,7 +18,7 @@ id: e9c11b1b-0caa-45c9-b9b2-592939c9a5a6
 description: CSB Amazon ElastiCache for Redis
 display_name: CSB Amazon ElastiCache for Redis
 image_url: file://service-images/csb.png
-documentation_url: https://docs.vmware.com/en/Cloud-Service-Broker-for-VMware-Tanzu/index.html
+documentation_url: https://techdocs.broadcom.com/tnz-aws-broker-cf
 provider_display_name: VMware
 support_url: https://aws.amazon.com/redis/
 tags: [aws, redis]

--- a/aws-s3-bucket.yml
+++ b/aws-s3-bucket.yml
@@ -18,7 +18,7 @@ id: ffe28d48-c235-4e07-9c51-ddff5699e48c
 description: CSB AWS S3 Bucket
 display_name: CSB AWS S3 Bucket
 image_url: file://service-images/csb.png
-documentation_url: https://docs.vmware.com/en/Cloud-Service-Broker-for-VMware-Tanzu/index.html
+documentation_url: https://techdocs.broadcom.com/tnz-aws-broker-cf
 provider_display_name: VMware
 support_url: https://aws.amazon.com/s3/
 tags: [aws, s3]

--- a/aws-sqs.yml
+++ b/aws-sqs.yml
@@ -4,7 +4,7 @@ id: 2198d694-bf85-11ee-a918-a7bdfa69a96d
 description: CSB AWS SQS
 display_name: CSB AWS SQS
 image_url: file://service-images/csb.png
-documentation_url: https://docs.vmware.com/en/Cloud-Service-Broker-for-VMware-Tanzu/index.html
+documentation_url: https://techdocs.broadcom.com/tnz-aws-broker-cf
 provider_display_name: VMware
 support_url: https://aws.amazon.com/sqs/
 tags: [aws, sqs]

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ The service broker is deployed to CloudFoundry as a `cf push`ed application.
 
 ## Cloud Service Broker General
 * Consuming Services are documented in Cloud Service Broker for VMware Tanzu for AWS official 
-[docs](https://docs.vmware.com/en/Cloud-Service-Broker-for-VMware-Tanzu/index.html).
+[docs](https://techdocs.broadcom.com/tnz-aws-broker-cf).
 
 ## Brokerpak Specifications
 * [Brokerpak Intro](https://github.com/cloudfoundry/cloud-service-broker/tree/main/docs/brokerpak-intro.md)

--- a/integration-tests/integration_test_suite_test.go
+++ b/integration-tests/integration_test_suite_test.go
@@ -24,7 +24,7 @@ const (
 	Name               = "Name"
 	ID                 = "ID"
 	fakeRegion         = "fake-region"
-	documentationURL   = "https://docs.vmware.com/en/Cloud-Service-Broker-for-VMware-Tanzu/index.html"
+	documentationURL   = "https://techdocs.broadcom.com/tnz-aws-broker-cf"
 )
 
 var (


### PR DESCRIPTION
Previous docs links results in an unhelpful redirect, while this new link goes to a more helpful place.