### PR TITLE
test: update for changed properties

### DIFF
--- a/terraform-tests/redis_test.go
+++ b/terraform-tests/redis_test.go
@@ -86,7 +86,6 @@ var _ = Describe("Redis", Label("redis-terraform"), Ordered, func() {
 					"description":                 Equal("csb-redis-test redis"),
 					"node_type":                   Equal("cache.t3.medium"),
 					"num_cache_clusters":          BeNumerically("==", 2),
-					"engine":                      Equal("redis"),
 					"engine_version":              Equal("6.0"),
 					"port":                        BeNumerically("==", 6379),
 					"tags":                        HaveKeyWithValue("key1", "some-redis-value"),


### PR DESCRIPTION
It seems that the aws_elasticache_replication_group resource no longer returns the engine type. This is likely to be an AWS API change as the provider version did not change. It has been stable for about 10 days, so we should update the test to match.