### PR TITLE
chore: apply fixes from Go modernize command

### DIFF
--- a/acceptance-tests/helpers/apps/prebuild.go
+++ b/acceptance-tests/helpers/apps/prebuild.go
@@ -23,7 +23,7 @@ func WithPreBuild(source string) Option {
 	Expect(err).NotTo(HaveOccurred())
 	Eventually(session, 5*time.Minute).Should(gexec.Exit(0))
 
-	err = os.WriteFile(path.Join(dir.path(), "Procfile"), []byte(fmt.Sprintf("web: ./%s\n", name)), 0555)
+	err = os.WriteFile(path.Join(dir.path(), "Procfile"), fmt.Appendf(nil, "web: ./%s\n", name), 0555)
 	Expect(err).NotTo(HaveOccurred())
 
 	return WithOptions(

--- a/acceptance-tests/helpers/awscli/dms/instance.go
+++ b/acceptance-tests/helpers/awscli/dms/instance.go
@@ -4,6 +4,7 @@ import (
 	"csbbrokerpakaws/acceptance-tests/helpers/awscli"
 	"csbbrokerpakaws/acceptance-tests/helpers/random"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -90,10 +91,5 @@ func replicationInstanceExists(arn, region string) bool {
 	}
 	awscli.AWSToJSON(&receiver, "dms", "describe-replication-instances", "--region", region)
 
-	for _, a := range receiver.ARNs {
-		if a == arn {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(receiver.ARNs, arn)
 }

--- a/acceptance-tests/helpers/awscli/dms/task.go
+++ b/acceptance-tests/helpers/awscli/dms/task.go
@@ -4,6 +4,7 @@ import (
 	"csbbrokerpakaws/acceptance-tests/helpers/awscli"
 	"csbbrokerpakaws/acceptance-tests/helpers/random"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -133,10 +134,5 @@ func replicationTaskExists(arn, region string) bool {
 	}
 	awscli.AWSToJSON(&receiver, "dms", "describe-replication-tasks", "--region", region)
 
-	for _, a := range receiver.ARNs {
-		if a == arn {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(receiver.ARNs, arn)
 }

--- a/acceptance-tests/helpers/brokers/envrc.go
+++ b/acceptance-tests/helpers/brokers/envrc.go
@@ -17,7 +17,7 @@ func readEnvrcServices(path string) (result []apps.EnvVar) {
 	data, err := os.ReadFile(path)
 	Expect(err).NotTo(HaveOccurred())
 
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		m := serviceMatcher.FindStringSubmatch(line)
 		const expectedNumberOfMatches = 3
 		if len(m) != expectedNumberOfMatches {

--- a/terraform-tests/helpers/resource_changes.go
+++ b/terraform-tests/helpers/resource_changes.go
@@ -14,7 +14,7 @@ func ResourceCreationForType(plan tfjson.Plan, resourceType string) []tfjson.Res
 	return result
 }
 
-func AfterValuesForType(plan tfjson.Plan, resourceType string) interface{} {
+func AfterValuesForType(plan tfjson.Plan, resourceType string) any {
 	for _, change := range plan.ResourceChanges {
 		if change.Type == resourceType {
 			return change.Change.After
@@ -23,8 +23,8 @@ func AfterValuesForType(plan tfjson.Plan, resourceType string) interface{} {
 	return nil
 }
 
-func GroupAfterValuesForType(plan tfjson.Plan, resourceType string) interface{} {
-	var ee []interface{}
+func GroupAfterValuesForType(plan tfjson.Plan, resourceType string) any {
+	var ee []any
 	for _, change := range plan.ResourceChanges {
 		if change.Type == resourceType {
 			ee = append(ee, change.Change.After)
@@ -33,7 +33,7 @@ func GroupAfterValuesForType(plan tfjson.Plan, resourceType string) interface{} 
 	return ee
 }
 
-func UnknownValuesForType(plan tfjson.Plan, resourceType string) interface{} {
+func UnknownValuesForType(plan tfjson.Plan, resourceType string) any {
 	for _, change := range plan.ResourceChanges {
 		if change.Type == resourceType {
 			return change.Change.AfterUnknown

--- a/terraform-tests/helpers/slice_filters_generic.go
+++ b/terraform-tests/helpers/slice_filters_generic.go
@@ -1,14 +1,10 @@
 package helpers
 
+import "slices"
+
 func Filter[T comparable](existingElements []T, elementsToFilter ...T) (filteredElements []T) {
 	for _, curElement := range existingElements {
-		hasToBeFiltered := false
-		for _, elementToFilter := range elementsToFilter {
-			if curElement == elementToFilter {
-				hasToBeFiltered = true
-				break
-			}
-		}
+		hasToBeFiltered := slices.Contains(elementsToFilter, curElement)
 		if !hasToBeFiltered {
 			filteredElements = append(filteredElements, curElement)
 		}

--- a/terraform-tests/mssql_test.go
+++ b/terraform-tests/mssql_test.go
@@ -998,7 +998,7 @@ func createVPCWithMoreThan20Subnets() (string, string, func()) {
 	Expect(err).NotTo(HaveOccurred())
 
 	var subnetIDs []string
-	for i := 0; i < numSubnets; i++ {
+	for i := range numSubnets {
 		createSubnetResult, err := ec2Client.CreateSubnet(context.Background(), &ec2.CreateSubnetInput{
 			VpcId:              createVPCResult.Vpc.VpcId,
 			CidrBlock:          pointer(fmt.Sprintf("10.0.%d.0/24", i)),


### PR DESCRIPTION
The modernize command replaces old constructs with simpler, updated ones.

Command is:
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...
