### PR TITLE
TNZ-101745: chore: Update OpenTofu to 1.11.5

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -16,11 +16,11 @@ terraform_state_provider_replacements:
   registry.opentofu.org/cloud-service-broker/csbmysql: "cloudfoundry.org/cloud-service-broker/csbmysql"
   registry.terraform.io/cloud-service-broker/csbmysql: "cloudfoundry.org/cloud-service-broker/csbmysql"
 terraform_upgrade_path:
-- version: 1.10.9
+- version: 1.11.5
 terraform_binaries:
 - name: tofu
-  version: 1.10.9
-  source: https://github.com/opentofu/opentofu/archive/v1.10.9.zip
+  version: 1.11.5
+  source: https://github.com/opentofu/opentofu/archive/v1.11.5.zip
   default: true
 - name: terraform-provider-aws
   version: 6.38.0


### PR DESCRIPTION
## Summary
* Updates OpenTofu minor version from 1.10.9 to 1.11.5.
* The CI will continue to automatically bump patch versions for the 1.11.x line.

Made with [Cursor](https://cursor.com)